### PR TITLE
fix: add repository/homepage/bugs fields for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,14 @@
   "version": "0.1.1",
   "description": "Shared Meda UI shell and runtime package.",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Medal-Social/meda.git"
+  },
+  "homepage": "https://github.com/Medal-Social/meda#readme",
+  "bugs": {
+    "url": "https://github.com/Medal-Social/meda/issues"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
The 0.1.1 publish attempt failed with npm error E422: `"repository.url" is "", expected to match "https://github.com/Medal-Social/meda" from provenance`. npm's provenance signer verifies that the package.json declares the GitHub repo it's being published from. Adding:

- `repository` (git URL)
- `homepage`
- `bugs`

Merging this will re-trigger the Release workflow which publishes 0.1.1 to npm.