### PR TITLE
chore: promote docs + ci retarget to prod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [prod]
+    branches: [dev, prod]
   pull_request:
-    branches: [prod]
+    branches: [dev, prod]
 
 permissions:
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: CodeQL
 
 on:
   push:
-    branches: [prod]
+    branches: [dev, prod]
   pull_request:
-    branches: [prod]
+    branches: [dev, prod]
   schedule:
     - cron: '0 6 * * 1'
 

--- a/.github/workflows/request-changeset.yml
+++ b/.github/workflows/request-changeset.yml
@@ -3,7 +3,7 @@ name: Request changeset
 on:
   pull_request:
     types: [opened, ready_for_review]
-    branches: [prod]
+    branches: [dev]
 
 permissions: {}
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,10 @@
 Shared Meda UI shell and runtime package. Public open-source, published to npm.
 
 ## Branch Strategy
-Single-trunk on `prod` (default branch). Feature work: `feat/*` → PR → `prod`. Changesets opens a "Release PR" (`changeset-release/prod` → `prod`) that bumps the version; merging it triggers the npm publish via OIDC.
+Two-branch flow: `feat/*` → PR → `dev` → PR → `prod`. `prod` is the default/stable branch. Changesets opens a "Release PR" (`changeset-release/prod` → `prod`) that bumps the version; merging it triggers the npm publish via OIDC.
 
 ## Release Pipeline
+- CI runs on pushes and PRs to both `dev` and `prod`
 - `release.yml` triggers on push to `prod`
 - Changesets action either opens the Release PR or, if the version bump is already committed, publishes directly
 - Uses npm OIDC trusted publishing (no static NPM_TOKEN)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,11 +27,13 @@ scripts/
 
 ## Pull Requests
 
-- Branch from `dev`
+- Branch from `dev` and target `dev` in your PR
+- Releases flow `dev → prod` via a second PR once a batch of changes is ready
 - Write or update tests for any behavior change
-- Ensure `pnpm test` and `pnpm build` pass before submitting
+- Ensure `pnpm lint`, `pnpm test`, and `pnpm build` pass before submitting
 - Add a changeset with `pnpm changeset` for any user-facing change
 - Do not commit generated `dist/` artifacts
+- The pre-commit hook runs `pnpm lint` and `pnpm test`; do not bypass with `--no-verify`
 
 ## Code Style
 
@@ -75,3 +77,39 @@ AI assistance is allowed, but contributors are responsible for the final patch.
 - Review every AI-generated change before committing
 - Write or update tests for any behavior change
 - Use your own commit message and PR summary
+
+## Working on Meda Alongside a Consumer App
+
+Meda is published to npm. Consumers install it as a normal dependency. For iterative work that spans Meda and a consumer (e.g. a sibling app), two workflows are supported:
+
+### 1. Snapshot release (preferred for PRs)
+
+Use Changesets snapshot versioning to publish a throwaway preview:
+
+```bash
+pnpm changeset                          # describe the change
+pnpm changeset version --snapshot dev   # versions as 0.x.y-dev-<sha>
+pnpm build
+pnpm publish --tag dev --no-git-checks  # publishes @medalsocial/meda@0.x.y-dev-<sha>
+```
+
+In the consumer app, pin to the snapshot:
+
+```json
+"@medalsocial/meda": "0.1.1-dev-abc1234"
+```
+
+### 2. `pnpm link` (local only)
+
+For rapid local iteration, link the built library into the consumer:
+
+```bash
+# in this repo (run from the package root — this is where package.json lives)
+pnpm build
+pnpm link --global
+
+# in the consumer
+pnpm link --global @medalsocial/meda
+```
+
+Unlink before committing — never commit `pnpm link` state.


### PR DESCRIPTION
Promotes PR #6 (two-branch docs + CI retarget to [dev, prod]) from dev to prod. No behavior change, just propagating the docs + ci trigger updates.