### PR TITLE
fix(ci): broaden request-changeset coverage (to prod)

### DIFF
--- a/.github/workflows/request-changeset.yml
+++ b/.github/workflows/request-changeset.yml
@@ -32,7 +32,9 @@ jobs:
           HAS_CHANGESET=$(echo "$CHANGED" | grep -c '^\.changeset/.*\.md$' || true)
 
           # Non-package-affecting paths that do NOT require a changeset even if they change.
-          NON_PKG=$(echo "$CHANGED" | grep -cE '^(\.github/|\.husky/|\.changeset/|demo/|registry/|docs/|\.gitignore$|\.editorconfig$|[^/]*\.md$|LICENSE$|NOTICE$|biome\.json$|vitest\.config\.ts$|vite\.config\.demo\.ts$)' || true)
+          # Includes CI, hooks, docs, demo, registry, and repo-governance/config files that
+          # don't ship in the npm tarball.
+          NON_PKG=$(echo "$CHANGED" | grep -cE '^(\.github/|\.husky/|\.changeset/|demo/|registry/|docs/|\.gitignore$|\.editorconfig$|\.npmrc$|CODEOWNERS$|[^/]*\.md$|LICENSE$|NOTICE$|biome\.json$|vitest\.config\.ts$|vite\.config\.demo\.ts$)' || true)
 
           # Everything else is assumed package-affecting (src/, scripts/, package.json,
           # tsconfig*.json, pnpm-workspace.yaml, pnpm-lock.yaml, top-level configs, etc.).

--- a/.github/workflows/request-changeset.yml
+++ b/.github/workflows/request-changeset.yml
@@ -3,7 +3,7 @@ name: Request changeset
 on:
   pull_request:
     types: [opened, ready_for_review]
-    branches: [dev]
+    branches: [dev, prod]
 
 permissions: {}
 
@@ -30,9 +30,16 @@ jobs:
           CHANGED=$(git diff --name-only ${{ github.event.pull_request.base.sha }} HEAD)
 
           HAS_CHANGESET=$(echo "$CHANGED" | grep -c '^\.changeset/.*\.md$' || true)
-          HAS_SRC=$(echo "$CHANGED" | grep -cE '^src/' || true)
 
-          if [[ "$HAS_CHANGESET" -eq 0 && "$HAS_SRC" -gt 0 ]]; then
+          # Non-package-affecting paths that do NOT require a changeset even if they change.
+          NON_PKG=$(echo "$CHANGED" | grep -cE '^(\.github/|\.husky/|\.changeset/|demo/|registry/|docs/|\.gitignore$|\.editorconfig$|[^/]*\.md$|LICENSE$|NOTICE$|biome\.json$|vitest\.config\.ts$|vite\.config\.demo\.ts$)' || true)
+
+          # Everything else is assumed package-affecting (src/, scripts/, package.json,
+          # tsconfig*.json, pnpm-workspace.yaml, pnpm-lock.yaml, top-level configs, etc.).
+          TOTAL_CHANGED=$(echo "$CHANGED" | grep -c . || true)
+          PKG_AFFECTING=$((TOTAL_CHANGED - NON_PKG))
+
+          if [[ "$HAS_CHANGESET" -eq 0 && "$PKG_AFFECTING" -gt 0 ]]; then
             echo "needed=true" >> "$GITHUB_OUTPUT"
           else
             echo "needed=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Brings #8's changes to prod directly. PR #9 (dev→prod) had a phantom conflict because #7 was squash-merged, so git couldn't detect that #6's workflow changes were already on prod.

## Commits (cherry-picked from dev)
- 181fa04 → c4ba6d7: trigger on [dev, prod] + exclude-list heuristic
- e271d22 → 5751523: add CODEOWNERS + .npmrc to NON_PKG

All bot feedback from #8 was addressed before cherry-pick.