### PR TITLE
fix(ci): use changeset publish so release is idempotent

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "test:run": "vitest run --environment jsdom",
     "typecheck": "tsc --noEmit",
     "version": "changeset version",
-    "release": "pnpm build && pnpm publish --access public --no-git-checks",
+    "release": "pnpm build && changeset publish",
     "registry:validate": "node ./registry/scripts/validate-registry.mjs"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Problem

Since 0.1.1 was published, every subsequent push to `prod` (via PR merges #7 and #10) retriggered the Release workflow and failed with:

```
npm error You cannot publish over the previously published versions: 0.1.1.
```

The release script used `pnpm publish` unconditionally, which always tries to push whatever version is in `package.json`. npm rightfully rejects duplicates.

## Fix

Swap to `changeset publish` which inspects npm per-package and only publishes versions that aren't already there. This is the pattern Pilot uses. When no changesets are pending, the workflow no-ops cleanly instead of throwing.

## Test plan
- [ ] CI green on this PR (lint/test/build/CodeQL)
- [ ] After merge to prod: Release workflow succeeds silently (nothing to publish)
- [ ] Next real changeset → Release opens a version PR + publishes the bump