### PR TITLE
fix(meda): re-export legacy ./styles.css subpath

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,9 @@
     "./styles": {
       "default": "./dist/styles/theme.css"
     },
+    "./styles.css": {
+      "default": "./dist/styles/theme.css"
+    },
     "./styles/tokens": {
       "default": "./dist/styles/tokens.css"
     }


### PR DESCRIPTION
## Why
Codex flagged a P1 on #34: the new exports map in 1.0.0-rc.1 removed the legacy \`@medalsocial/meda/styles.css\` subpath when introducing \`./styles\` and \`./styles/tokens\`. With an \`exports\` map present, any subpath not listed is a hard error (\`ERR_PACKAGE_PATH_NOT_EXPORTED\`), which silently breaks every consumer still importing \`@medalsocial/meda/styles.css\` — including this repo's own README and demo.

## What
Add \`./styles.css\` back to \`exports\` as a thin legacy alias pointing at the same \`./dist/styles/theme.css\` artifact that \`./styles\` exposes. New code should use \`./styles\`; \`./styles.css\` is preserved purely to avoid a surprise breakage on the 1.0.0-rc.1 cut.

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` 545/545 passing locally
- [ ] CI green