### PR TITLE
ci(meda): install playwright chromium in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,13 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # changesets/action stages + commits the version bump, which fires the
+      # Husky pre-commit hook (lint + test). The vitest 'storybook' project
+      # runs every *.stories.tsx in headless Chromium via @vitest/browser-
+      # playwright, so the browser binary needs to be present before that
+      # commit. --with-deps installs the required system libs on Ubuntu.
+      - run: pnpm exec playwright install chromium --with-deps
+
       - run: pnpm build
 
       - name: Create release PR or publish packages


### PR DESCRIPTION
## Why
The previous release.yml run failed: \`changesets/action\` commits a version-bump locally, which fires Husky's pre-commit hook (\`pnpm lint && pnpm test\`). The vitest \`storybook\` project added in 1.0.0-rc.1 runs every \`*.stories.tsx\` in headless Chromium via \`@vitest/browser-playwright\`. The release workflow doesn't have the browser binary installed, so the test step fails with \`Executable doesn't exist at ms-playwright/chromium_headless_shell\` — the same issue we already fixed in \`ci.yml\` for the test job.

## What
Add \`pnpm exec playwright install chromium --with-deps\` after \`pnpm install\` and before \`pnpm build\` / the changesets action.

## Test plan
- [x] Mirrors the fix on \`ci.yml\` that's already running green on PR-side workflows.
- [ ] Once merged, re-run release.yml (push to prod or workflow_dispatch) and confirm the version PR opens.