### PR TITLE
Recast storybook-cleanup changeset from major to minor (stay on 1.x)

### DIFF
--- a/.changeset/storybook-cleanup.md
+++ b/.changeset/storybook-cleanup.md
@@ -2,9 +2,9 @@
 '@medalsocial/meda': minor
 ---
 
-Storybook cleanup and AppShell unification. Shipped as a `minor` to keep `@medalsocial/meda` on the 1.x line — the API changes below are technically breaking but no consumers exist yet, so we are not spending the major bump here.
+Storybook cleanup and AppShell unification. The package is on `1.0.0-rc.1` with no real-world consumers yet, so the API reshape below ships as a `minor` to land before `1.0.0` rather than as a `major`. Treat this as part of the original `1.0.0` API surface — the components removed below were never depended on by any external app.
 
-**API changes:**
+**API surface changes (rolled into the `1.0.0` release):**
 - `<AppShell>` now requires a `variant` prop: `"auth" | "workspace" | "chat"`. Composition is config-driven via `iconRail`, `contextRail`, `rightPanel`, `globalActions`, and `auth` props.
 - `MobileHeader`, `MobileBottomNav`, `MobileDrawers`, `ShellAuthFrame`, and `ShellAuthThemeToggle` are removed. Their behavior is now internal to `<AppShell variant="auth">` and `<AppShell variant="workspace">`. The viewport switch is automatic.
 

--- a/.changeset/storybook-cleanup.md
+++ b/.changeset/storybook-cleanup.md
@@ -1,10 +1,10 @@
 ---
-'@medalsocial/meda': major
+'@medalsocial/meda': minor
 ---
 
-Storybook cleanup and AppShell unification.
+Storybook cleanup and AppShell unification. Shipped as a `minor` to keep `@medalsocial/meda` on the 1.x line — the API changes below are technically breaking but no consumers exist yet, so we are not spending the major bump here.
 
-**Breaking changes:**
+**API changes:**
 - `<AppShell>` now requires a `variant` prop: `"auth" | "workspace" | "chat"`. Composition is config-driven via `iconRail`, `contextRail`, `rightPanel`, `globalActions`, and `auth` props.
 - `MobileHeader`, `MobileBottomNav`, `MobileDrawers`, `ShellAuthFrame`, and `ShellAuthThemeToggle` are removed. Their behavior is now internal to `<AppShell variant="auth">` and `<AppShell variant="workspace">`. The viewport switch is automatic.
 


### PR DESCRIPTION
Tiny fix on top of #41.

The storybook-cleanup changeset was set to **major**, but the existing **meda-shell-v2** major changeset already drives 1.0.0-rc.1 → 1.0.0 for this release. Two majors don't compound — the result is still 1.0.0 either way.

Recasting storybook-cleanup as **minor** keeps the published version unchanged (1.0.0) and removes the redundant 'major intent'. The next time someone proposes a real major, we'll be on 1.0.0 with a clean slate to decide whether to spend the 2.0.0 bump.

Per @alioftech: stay on 1.x at all cost.