### PR TITLE
chore: sync prod into dev (1.1.1)

### DIFF
--- a/.changeset/context-rail-collapse-toggle.md
+++ b/.changeset/context-rail-collapse-toggle.md
@@ -1,5 +1,0 @@
----
-'@medalsocial/meda': patch
----
-
-`<ContextRail>` now ships with an always-visible chevron toggle on its right edge that collapses and re-expands the rail. The chevron sits on the rail's edge when expanded and naturally migrates to the IconRail's right edge when collapsed. Width animates with a 200ms ease-in-out transition (or instant snap for users with `prefers-reduced-motion: reduce`). The collapsed state was already persisted per-workspace via `ctx.contextRail.collapsed`; this release adds the UI affordance to flip it. No public API change — works automatically inside `<AppShell variant="workspace">`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @medalsocial/meda
 
+## 1.1.1
+
+### Patch Changes
+
+- [#50](https://github.com/Medal-Social/meda/pull/50) [`7fdf4bb`](https://github.com/Medal-Social/meda/commit/7fdf4bb30264527de8011e2b1e7cd3d062c82d69) Thanks [@alioftech](https://github.com/alioftech)! - `<ContextRail>` now ships with an always-visible chevron toggle on its right edge that collapses and re-expands the rail. The chevron sits on the rail's edge when expanded and naturally migrates to the IconRail's right edge when collapsed. Width animates with a 200ms ease-in-out transition (or instant snap for users with `prefers-reduced-motion: reduce`). The collapsed state was already persisted per-workspace via `ctx.contextRail.collapsed`; this release adds the UI affordance to flip it. No public API change — works automatically inside `<AppShell variant="workspace">`.
+
 ## 1.1.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@medalsocial/meda",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Shared Meda UI shell and runtime package.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary

Brings prod's 1.1.1 release back into dev so future dev → prod PRs (e.g. #57) don't replay an already-consumed changeset or conflict on package.json.

## What this does

- Bumps \`package.json\` from 1.1.0 → 1.1.1 (matches prod)
- Adds the 1.1.1 entry to \`CHANGELOG.md\`
- Removes \`.changeset/context-rail-collapse-toggle.md\` (already consumed by the prod release)

## After merge

PR #57 (dev → prod) becomes a clean fast-forward of just the shell-main-left-align changeset, ready to release as 1.1.2.