### PR TITLE
chore: sync prod → dev (backport changeset-release/prod #59)

### DIFF
--- a/.changeset/shell-main-left-align.md
+++ b/.changeset/shell-main-left-align.md
@@ -1,5 +1,0 @@
----
-"@medalsocial/meda": patch
----
-
-`ShellMain`'s default `workspace` layout now left-aligns content within its `max-w-[1280px]` cap instead of centering it. This removes the unused band that appeared on the left of the work area when `ContextRail` was collapsed. Pages that need horizontally centered reading should opt into `layout="centered"`; pages that want full bleed already use `layout="fullbleed"`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @medalsocial/meda
 
+## 1.1.2
+
+### Patch Changes
+
+- [#56](https://github.com/Medal-Social/meda/pull/56) [`8649dc7`](https://github.com/Medal-Social/meda/commit/8649dc753e58bc5a0b835203bfa553b9d723e239) Thanks [@alioftech](https://github.com/alioftech)! - `ShellMain`'s default `workspace` layout now left-aligns content within its `max-w-[1280px]` cap instead of centering it. This removes the unused band that appeared on the left of the work area when `ContextRail` was collapsed. Pages that need horizontally centered reading should opt into `layout="centered"`; pages that want full bleed already use `layout="fullbleed"`.
+
 ## 1.1.1
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@medalsocial/meda",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Shared Meda UI shell and runtime package.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Backports the previous release commit (`00471ad chore: release @medalsocial/meda`) and the changeset-release merge from prod back to dev. Required so PR #61 (dev → prod) can fast-forward without the "branch out of date" block.