### PR TITLE
fix: KanbanBoard className + ListCell shrink semantics

### DIFF
--- a/.changeset/meda-className-and-listcell-shrink.md
+++ b/.changeset/meda-className-and-listcell-shrink.md
@@ -1,0 +1,5 @@
+---
+"@medalsocial/meda": patch
+---
+
+Fix `KanbanBoardProps.className` not being applied to the board wrapper. Fix `ListCell.shrink` flag being inverted from its documented behavior — `shrink={true}` now correctly allows shrinking; `shrink={false}` adds `flex-shrink-0`. Backwards-compatible for default usage.

--- a/dist/kanban/kanban-board.js
+++ b/dist/kanban/kanban-board.js
@@ -28,7 +28,7 @@ function resolveOverColumnStatus(overId, columns, items) {
  * `useDndMonitor` is always safe to call here, enabling the DragOverlay to
  * track external drags when `headless={true}`.
  */
-function KanbanBoardInner({ columns, items, renderCard, onReorder, onCardMove, canDropCard, onAddItem, showEmptyColumns = false, hiddenColumnIds = [], onHiddenColumnIdsChange, emptyColumnContent, labels, headless = false, }) {
+function KanbanBoardInner({ columns, items, renderCard, onReorder, onCardMove, canDropCard, onAddItem, showEmptyColumns = false, hiddenColumnIds = [], onHiddenColumnIdsChange, emptyColumnContent, labels, headless = false, className, }) {
     const resolvedLabels = { ...defaultKanbanLabels, ...(labels ?? {}) };
     const [activeId, setActiveId] = useState(null);
     const [overColumnId, setOverColumnId] = useState(null);
@@ -134,7 +134,7 @@ function KanbanBoardInner({ columns, items, renderCard, onReorder, onCardMove, c
             return;
         onHiddenColumnIdsChange(hiddenColumnIds.filter((hiddenColumnId) => hiddenColumnId !== columnId));
     }, [hiddenColumnIds, onHiddenColumnIdsChange]);
-    return (_jsxs(_Fragment, { children: [_jsxs("div", { "data-slot": "kanban-board", className: "flex h-full gap-4 pb-4", children: [visibleColumns.map((column) => {
+    return (_jsxs(_Fragment, { children: [_jsxs("div", { "data-slot": "kanban-board", className: cn('flex h-full gap-4 pb-4', className), children: [visibleColumns.map((column) => {
                         const columnItems = itemsByStatus.get(column.id) ?? [];
                         const canDropInColumn = !activeId ||
                             !canDropCard ||

--- a/dist/list/list-row.js
+++ b/dist/list/list-row.js
@@ -32,6 +32,6 @@ export function ListRow({ selected, selectionActive, onSelect, onClick, onMouseE
                         : 'opacity-0 group-hover:opacity-100 data-[state=checked]:opacity-100') }) })), children] }));
 }
 export function ListCell({ width = 'flex-1', shrink = true, align = 'left', children, className, }) {
-    return (_jsx("div", { className: cn(width, shrink && 'flex-shrink-0', align === 'center' && 'text-center', align === 'right' && 'text-right', 'min-w-0', // Allow truncation
+    return (_jsx("div", { className: cn(width, shrink === false && 'flex-shrink-0', align === 'center' && 'text-center', align === 'right' && 'text-right', 'min-w-0', // Allow truncation
         className), children: children }));
 }

--- a/src/kanban/kanban-board.tsx
+++ b/src/kanban/kanban-board.tsx
@@ -80,6 +80,7 @@ function KanbanBoardInner<TItem extends KanbanItem, TStatus extends string = str
   emptyColumnContent,
   labels,
   headless = false,
+  className,
 }: KanbanBoardProps<TItem, TStatus>) {
   const resolvedLabels: KanbanLabels = { ...defaultKanbanLabels, ...(labels ?? {}) };
 
@@ -228,7 +229,7 @@ function KanbanBoardInner<TItem extends KanbanItem, TStatus extends string = str
 
   return (
     <>
-      <div data-slot="kanban-board" className="flex h-full gap-4 pb-4">
+      <div data-slot="kanban-board" className={cn('flex h-full gap-4 pb-4', className)}>
         {visibleColumns.map((column) => {
           const columnItems = itemsByStatus.get(column.id as TStatus) ?? [];
           const canDropInColumn =

--- a/src/list/list-row.tsx
+++ b/src/list/list-row.tsx
@@ -147,7 +147,7 @@ export function ListCell({
     <div
       className={cn(
         width,
-        shrink && 'flex-shrink-0',
+        shrink === false && 'flex-shrink-0',
         align === 'center' && 'text-center',
         align === 'right' && 'text-right',
         'min-w-0', // Allow truncation


### PR DESCRIPTION
Two P2 a11y / API-correctness fixes flagged by Codex on PR #61 (dev → prod).

## Fixes

- **KanbanBoardProps.className not applied** — board wrapper now merges caller's `className` with the default classes via `cn(...)`. Consumers can style/size the board.
- **ListCell.shrink semantic was inverted** — `shrink={true}` (docs: "Whether to shrink if needed") was adding `flex-shrink-0` which prevents shrinking. Flipped: `shrink={true}` now allows shrinking (default), `shrink={false}` adds `flex-shrink-0`.

## Test plan

- [ ] CI green
- [ ] Storybook renders KanbanBoard story without regression
- [ ] PR #61 picks up these commits and Codex's threads resolve

## Changeset

`.changeset/meda-className-and-listcell-shrink.md` — `@medalsocial/meda` patch bump.