### PR TITLE
Dynamic shell composition

### DIFF
--- a/.changeset/meda-shell-dynamic-composition.md
+++ b/.changeset/meda-shell-dynamic-composition.md
@@ -1,0 +1,5 @@
+---
+'@medalsocial/meda': minor
+---
+
+Add dynamic shell composition APIs: context modules can render custom content in desktop and mobile rails, and route content can register right-panel views with PanelViewsProvider.

--- a/dist/shell/app-shell-workspace.js
+++ b/dist/shell/app-shell-workspace.js
@@ -6,6 +6,7 @@ import { IconRail } from './icon-rail.js';
 import { MobileBottomNav } from './internal/mobile-bottom-nav.js';
 import { MobileDrawers } from './internal/mobile-drawers.js';
 import { MobileHeader } from './internal/mobile-header.js';
+import { useResolvedPanelViews } from './panel-views-provider.js';
 import { RightPanel } from './right-panel.js';
 import { ShellHeader } from './shell-header.js';
 import { ShellMain } from './shell-main.js';
@@ -13,11 +14,12 @@ import { useShellViewport } from './use-shell-viewport.js';
 export function AppShellWorkspace({ iconRail, contextRail, rightPanel, globalActions, children, }) {
     const viewport = useShellViewport();
     const isMobile = viewport === 'mobile';
+    const resolvedRightPanel = useResolvedPanelViews(rightPanel?.panelViews ?? [], rightPanel?.defaultView);
     // Derive the bottom-nav items from the variant config so each button maps
     // to a drawer that actually has content. Without this filter, partial
     // configs (e.g. iconRail only) would show Module/Panels/AI buttons that
     // dispatch into the void.
-    const navItems = buildMobileNavItems(iconRail, contextRail, rightPanel);
+    const navItems = buildMobileNavItems(iconRail, contextRail, resolvedRightPanel.panelViews);
     const hasDrawerContent = navItems.length > 0;
     // Mobile menu drawer needs both main and utility items — desktop IconRail
     // shows both, so dropping utilityItems here would orphan items like Help/
@@ -33,21 +35,22 @@ export function AppShellWorkspace({ iconRail, contextRail, rightPanel, globalAct
     // rendered without an explicit-height ancestor (tests, direct imports). The
     // <AppShell> wrapper already enforces h-screen for the workspace variant, so
     // nested viewport-height divs collapse cleanly — no double-scroll.
-    return (_jsxs("div", { className: "flex h-screen flex-col", children: [isMobile ? (_jsx(MobileHeader, { globalActions: globalActions })) : (_jsx(ShellHeader, { globalActions: globalActions })), _jsxs("div", { className: "relative flex flex-1 overflow-hidden", children: [!isMobile && iconRail && (_jsx(IconRail, { mainItems: iconRail.mainItems, utilityItems: iconRail.utilityItems, footer: iconRail.footer, activeId: iconRail.activeId, renderLink: iconRail.renderLink })), !isMobile && contextRail && (_jsx(ContextRail, { appId: contextRail.appId, module: contextRail.module, activeItemId: contextRail.activeItemId })), _jsx(ShellMain, { layout: "workspace", children: children }), !isMobile && rightPanel && (_jsx(RightPanel, { panelViews: rightPanel.panelViews, defaultView: rightPanel.defaultView }))] }), isMobile && hasDrawerContent && _jsx(MobileBottomNav, { items: navItems }), isMobile && hasDrawerContent && (_jsx(MobileDrawers, { menuItems: mobileMenuItems, menuActiveId: iconRail?.activeId, menuRenderLink: iconRail?.renderLink, module: contextRail?.module, panelViews: rightPanel?.panelViews ?? [], defaultView: rightPanel?.defaultView }))] }));
+    return (_jsxs("div", { className: "flex h-screen flex-col", children: [isMobile ? (_jsx(MobileHeader, { globalActions: globalActions })) : (_jsx(ShellHeader, { globalActions: globalActions })), _jsxs("div", { className: "relative flex flex-1 overflow-hidden", children: [!isMobile && iconRail && (_jsx(IconRail, { mainItems: iconRail.mainItems, utilityItems: iconRail.utilityItems, footer: iconRail.footer, activeId: iconRail.activeId, renderLink: iconRail.renderLink })), !isMobile && contextRail && (_jsx(ContextRail, { appId: contextRail.appId, module: contextRail.module, activeItemId: contextRail.activeItemId })), _jsx(ShellMain, { layout: "workspace", children: children }), !isMobile && resolvedRightPanel.panelViews.length > 0 && (_jsx(RightPanel, { panelViews: rightPanel?.panelViews ?? [], defaultView: rightPanel?.defaultView }))] }), isMobile && hasDrawerContent && _jsx(MobileBottomNav, { items: navItems }), isMobile && hasDrawerContent && (_jsx(MobileDrawers, { menuItems: mobileMenuItems, menuActiveId: iconRail?.activeId, menuRenderLink: iconRail?.renderLink, module: contextRail?.module, moduleAppId: contextRail?.appId, panelViews: resolvedRightPanel.panelViews, defaultView: resolvedRightPanel.defaultView }))] }));
 }
-function buildMobileNavItems(iconRail, contextRail, rightPanel) {
+function buildMobileNavItems(iconRail, contextRail, panelViews) {
     const items = [];
     if (iconRail) {
         items.push({ id: 'menu', label: 'Menu', icon: Menu, opens: 'menu-drawer' });
     }
-    if (contextRail?.module) {
+    if (contextRail?.module &&
+        ((contextRail.module.items ?? []).length > 0 || Boolean(contextRail.module.render))) {
         items.push({ id: 'module', label: 'Module', icon: LayoutGrid, opens: 'module-drawer' });
     }
     // Panels button only when there's an actual view to render — empty
     // panelViews would open an empty drawer (dead-end tap).
-    if (rightPanel && rightPanel.panelViews.length > 0) {
+    if (panelViews.length > 0) {
         items.push({ id: 'panels', label: 'Panels', icon: PanelTop, opens: 'panels-drawer' });
-        if (rightPanel.panelViews.some((v) => v.id === 'ai')) {
+        if (panelViews.some((v) => v.id === 'ai')) {
             items.push({ id: 'ai', label: 'AI', icon: Sparkles, opens: 'ai-drawer' });
         }
     }

--- a/dist/shell/app-shell-workspace.js
+++ b/dist/shell/app-shell-workspace.js
@@ -11,10 +11,12 @@ import { RightPanel } from './right-panel.js';
 import { ShellHeader } from './shell-header.js';
 import { ShellMain } from './shell-main.js';
 import { useShellViewport } from './use-shell-viewport.js';
+const EMPTY_PANEL_VIEWS = [];
 export function AppShellWorkspace({ iconRail, contextRail, rightPanel, globalActions, children, }) {
     const viewport = useShellViewport();
     const isMobile = viewport === 'mobile';
-    const resolvedRightPanel = useResolvedPanelViews(rightPanel?.panelViews ?? [], rightPanel?.defaultView);
+    const staticPanelViews = rightPanel?.panelViews ?? EMPTY_PANEL_VIEWS;
+    const resolvedRightPanel = useResolvedPanelViews(staticPanelViews, rightPanel?.defaultView);
     // Derive the bottom-nav items from the variant config so each button maps
     // to a drawer that actually has content. Without this filter, partial
     // configs (e.g. iconRail only) would show Module/Panels/AI buttons that
@@ -35,7 +37,7 @@ export function AppShellWorkspace({ iconRail, contextRail, rightPanel, globalAct
     // rendered without an explicit-height ancestor (tests, direct imports). The
     // <AppShell> wrapper already enforces h-screen for the workspace variant, so
     // nested viewport-height divs collapse cleanly — no double-scroll.
-    return (_jsxs("div", { className: "flex h-screen flex-col", children: [isMobile ? (_jsx(MobileHeader, { globalActions: globalActions })) : (_jsx(ShellHeader, { globalActions: globalActions })), _jsxs("div", { className: "relative flex flex-1 overflow-hidden", children: [!isMobile && iconRail && (_jsx(IconRail, { mainItems: iconRail.mainItems, utilityItems: iconRail.utilityItems, footer: iconRail.footer, activeId: iconRail.activeId, renderLink: iconRail.renderLink })), !isMobile && contextRail && (_jsx(ContextRail, { appId: contextRail.appId, module: contextRail.module, activeItemId: contextRail.activeItemId })), _jsx(ShellMain, { layout: "workspace", children: children }), !isMobile && resolvedRightPanel.panelViews.length > 0 && (_jsx(RightPanel, { panelViews: rightPanel?.panelViews ?? [], defaultView: rightPanel?.defaultView }))] }), isMobile && hasDrawerContent && _jsx(MobileBottomNav, { items: navItems }), isMobile && hasDrawerContent && (_jsx(MobileDrawers, { menuItems: mobileMenuItems, menuActiveId: iconRail?.activeId, menuRenderLink: iconRail?.renderLink, module: contextRail?.module, moduleAppId: contextRail?.appId, panelViews: resolvedRightPanel.panelViews, defaultView: resolvedRightPanel.defaultView }))] }));
+    return (_jsxs("div", { className: "flex h-screen flex-col", children: [isMobile ? (_jsx(MobileHeader, { globalActions: globalActions })) : (_jsx(ShellHeader, { globalActions: globalActions })), _jsxs("div", { className: "relative flex flex-1 overflow-hidden", children: [!isMobile && iconRail && (_jsx(IconRail, { mainItems: iconRail.mainItems, utilityItems: iconRail.utilityItems, footer: iconRail.footer, activeId: iconRail.activeId, renderLink: iconRail.renderLink })), !isMobile && contextRail && (_jsx(ContextRail, { appId: contextRail.appId, module: contextRail.module, activeItemId: contextRail.activeItemId })), _jsx(ShellMain, { layout: "workspace", children: children }), !isMobile && resolvedRightPanel.panelViews.length > 0 && (_jsx(RightPanel, { panelViews: staticPanelViews, defaultView: rightPanel?.defaultView }))] }), isMobile && hasDrawerContent && _jsx(MobileBottomNav, { items: navItems }), isMobile && hasDrawerContent && (_jsx(MobileDrawers, { menuItems: mobileMenuItems, menuActiveId: iconRail?.activeId, menuRenderLink: iconRail?.renderLink, module: contextRail?.module, moduleAppId: contextRail?.appId, panelViews: resolvedRightPanel.panelViews, defaultView: resolvedRightPanel.defaultView }))] }));
 }
 function buildMobileNavItems(iconRail, contextRail, panelViews) {
     const items = [];

--- a/dist/shell/context-rail.d.ts
+++ b/dist/shell/context-rail.d.ts
@@ -14,4 +14,4 @@ export interface ContextRailProps {
     renderLink?: (args: ShellLinkRenderArgs) => ReactNode;
     className?: string;
 }
-export declare function ContextRail({ appId: _appId, module, hidden, collapsible, activeItemId, renderLink, className, }: ContextRailProps): import("react/jsx-runtime").JSX.Element | null;
+export declare function ContextRail({ appId, module, hidden, collapsible, activeItemId, renderLink, className, }: ContextRailProps): import("react/jsx-runtime").JSX.Element | null;

--- a/dist/shell/context-rail.js
+++ b/dist/shell/context-rail.js
@@ -75,7 +75,7 @@ function ContextRailToggle({ railId }) {
 // ---------------------------------------------------------------------------
 // ContextRail
 // ---------------------------------------------------------------------------
-export function ContextRail({ appId: _appId, module, hidden = false, collapsible = true, activeItemId, renderLink, className, }) {
+export function ContextRail({ appId, module, hidden = false, collapsible = true, activeItemId, renderLink, className, }) {
     const band = useShellViewport();
     const ctx = useMedaShell();
     // collapsible={false} means the rail must always render expanded — even if
@@ -91,12 +91,13 @@ export function ContextRail({ appId: _appId, module, hidden = false, collapsible
     // is called on pointerUp to persist via useShellLayoutState.
     const [displayWidth, setDisplayWidth] = useState(null);
     const width = displayWidth ?? ctx.contextRail.width;
+    const items = module?.items ?? [];
     if (band === 'mobile')
         return null;
     if (hidden) {
         return _jsx("div", { "aria-hidden": "true", className: "hidden", "data-testid": "context-rail-hidden" });
     }
-    if (!module || module.items.length === 0) {
+    if (!module || (items.length === 0 && !module.render)) {
         return _jsx("div", { "aria-hidden": "true", className: "hidden", "data-testid": "context-rail-empty" });
     }
     const handleResize = (w) => {
@@ -112,7 +113,7 @@ export function ContextRail({ appId: _appId, module, hidden = false, collapsible
     // transition then so the rail snaps to the cursor instead of lagging
     // behind it.
     const isDragging = displayWidth !== null;
-    return (_jsxs("aside", { id: railId, "data-testid": "context-rail", "aria-label": module.label, className: cn('relative h-full shrink-0 border-r border-shell-border bg-shell-context', !isDragging && 'transition-[width] duration-200 ease-in-out motion-reduce:transition-none', collapsed && 'w-0', className), style: { width: collapsed ? 0 : width }, children: [collapsible && _jsx(ContextRailToggle, { railId: railId }), _jsxs("div", { className: "h-full overflow-hidden", "aria-hidden": collapsed, inert: collapsed || undefined, children: [_jsxs("div", { className: "border-b border-shell-border px-4 py-3", children: [_jsx("h2", { className: "text-sm font-semibold text-foreground", children: module.label }), module.description && (_jsx("p", { className: "mt-0.5 text-xs text-muted-foreground", children: module.description }))] }), _jsx("nav", { "aria-label": `${module.label} navigation`, className: "flex flex-col gap-0.5 p-2", children: module.items.map((item) => {
+    return (_jsxs("aside", { id: railId, "data-testid": "context-rail", "aria-label": module.label, className: cn('relative h-full shrink-0 border-r border-shell-border bg-shell-context', !isDragging && 'transition-[width] duration-200 ease-in-out motion-reduce:transition-none', collapsed && 'w-0', className), style: { width: collapsed ? 0 : width }, children: [collapsible && _jsx(ContextRailToggle, { railId: railId }), _jsxs("div", { className: "h-full overflow-hidden", "aria-hidden": collapsed, inert: collapsed || undefined, children: [_jsxs("div", { className: "border-b border-shell-border px-4 py-3", children: [_jsx("h2", { className: "text-sm font-semibold text-foreground", children: module.label }), module.description && (_jsx("p", { className: "mt-0.5 text-xs text-muted-foreground", children: module.description }))] }), items.length > 0 && (_jsx("nav", { "aria-label": `${module.label} navigation`, className: "flex flex-col gap-0.5 p-2", children: items.map((item) => {
                             const isActive = item.id === activeItemId;
                             const klass = cn('flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors', isActive
                                 ? 'bg-primary/10 text-primary'
@@ -123,5 +124,5 @@ export function ContextRail({ appId: _appId, module, hidden = false, collapsible
                                 return renderLink({ item, isActive, className: klass, children: inner });
                             }
                             return (_jsx("a", { href: item.to, "aria-current": isActive ? 'page' : undefined, className: klass, children: inner }, item.id));
-                        }) })] }), !collapsed && (_jsx(ResizeHandle, { currentWidth: width, onResize: handleResize, onCommit: handleCommit }))] }));
+                        }) })), module.render?.({ workspaceId: ctx.workspace.id, appId })] }), !collapsed && (_jsx(ResizeHandle, { currentWidth: width, onResize: handleResize, onCommit: handleCommit }))] }));
 }

--- a/dist/shell/index.d.ts
+++ b/dist/shell/index.d.ts
@@ -9,6 +9,8 @@ export { IconRail, RailDivider } from './icon-rail.js';
 export type { ShellStorageAdapter } from './layout-state.js';
 export { createLocalStorageAdapter } from './layout-state.js';
 export { motion } from './motion.js';
+export type { PanelViewsProviderProps } from './panel-views-provider.js';
+export { PanelViewsProvider } from './panel-views-provider.js';
 export type { RailDropSlotProps, RailDropSlotState } from './rail-drop-slot.js';
 export { RailDropSlot } from './rail-drop-slot.js';
 export type { RailDropZonesProps } from './rail-drop-zones.js';

--- a/dist/shell/index.js
+++ b/dist/shell/index.js
@@ -18,6 +18,7 @@ export { IconRail, RailDivider } from './icon-rail.js';
 export { createLocalStorageAdapter } from './layout-state.js';
 // Hooks + tokens
 export { motion } from './motion.js';
+export { PanelViewsProvider } from './panel-views-provider.js';
 // Resize primitives
 export { RailDropSlot } from './rail-drop-slot.js';
 export { RailDropZones } from './rail-drop-zones.js';

--- a/dist/shell/internal/mobile-drawers.d.ts
+++ b/dist/shell/internal/mobile-drawers.d.ts
@@ -10,6 +10,8 @@ export interface MobileDrawersProps {
     menuRenderLink?: IconRailProps['renderLink'];
     /** Module drawer source (current app's context-rail module). */
     module?: ContextModule;
+    /** App id used when rendering module custom content. */
+    moduleAppId?: string;
     /** Panels drawer source. */
     panelViews?: PanelView[];
     /**
@@ -27,4 +29,4 @@ export interface MobileDrawersProps {
  * any custom-content drawers. Mount once near the AppShell root; drawers
  * open/close via `ctx.mobileDrawer.open` provider state.
  */
-export declare function MobileDrawers({ menuItems, menuActiveId, menuRenderLink, module, panelViews, defaultView, customContent, }: MobileDrawersProps): import("react/jsx-runtime").JSX.Element;
+export declare function MobileDrawers({ menuItems, menuActiveId, menuRenderLink, module, moduleAppId, panelViews, defaultView, customContent, }: MobileDrawersProps): import("react/jsx-runtime").JSX.Element;

--- a/dist/shell/internal/mobile-drawers.js
+++ b/dist/shell/internal/mobile-drawers.js
@@ -9,7 +9,7 @@ import { useMedaShell } from '../shell-provider.js';
  * any custom-content drawers. Mount once near the AppShell root; drawers
  * open/close via `ctx.mobileDrawer.open` provider state.
  */
-export function MobileDrawers({ menuItems = [], menuActiveId, menuRenderLink, module, panelViews = [], defaultView, customContent = {}, }) {
+export function MobileDrawers({ menuItems = [], menuActiveId, menuRenderLink, module, moduleAppId, panelViews = [], defaultView, customContent = {}, }) {
     const ctx = useMedaShell();
     const open = ctx.mobileDrawer.open;
     const setOpen = ctx.mobileDrawer.setOpen;
@@ -18,7 +18,11 @@ export function MobileDrawers({ menuItems = [], menuActiveId, menuRenderLink, mo
         workspaceId: ctx.workspace.id,
         appId: ctx.activeAppId,
     };
-    return (_jsxs(_Fragment, { children: [_jsx(MenuDrawer, { open: open === 'menu-drawer', onClose: close, items: menuItems, activeId: menuActiveId, renderLink: menuRenderLink }), _jsx(ModuleDrawer, { open: open === 'module-drawer', onClose: close, module: module }), _jsx(PanelsDrawer, { open: open === 'panels-drawer', onClose: close, panelViews: panelViews, defaultView: defaultView, renderCtx: renderCtx }), _jsx(AiDrawer, { open: open === 'ai-drawer', onClose: close, panelViews: panelViews, renderCtx: renderCtx }), Object.entries(customContent).map(([id, renderFn]) => (_jsx(Drawer, { open: open === id, onOpenChange: (o) => !o && close(), direction: "bottom", children: _jsx(DrawerContent, { children: renderFn(close) }) }, id)))] }));
+    const moduleRenderCtx = {
+        workspaceId: ctx.workspace.id,
+        appId: moduleAppId ?? ctx.activeAppId,
+    };
+    return (_jsxs(_Fragment, { children: [_jsx(MenuDrawer, { open: open === 'menu-drawer', onClose: close, items: menuItems, activeId: menuActiveId, renderLink: menuRenderLink }), _jsx(ModuleDrawer, { open: open === 'module-drawer', onClose: close, module: module, renderCtx: moduleRenderCtx }), _jsx(PanelsDrawer, { open: open === 'panels-drawer', onClose: close, panelViews: panelViews, defaultView: defaultView, renderCtx: renderCtx }), _jsx(AiDrawer, { open: open === 'ai-drawer', onClose: close, panelViews: panelViews, renderCtx: renderCtx }), Object.entries(customContent).map(([id, renderFn]) => (_jsx(Drawer, { open: open === id, onOpenChange: (o) => !o && close(), direction: "bottom", children: _jsx(DrawerContent, { children: renderFn(close) }) }, id)))] }));
 }
 // ---------------------------------------------------------------------------
 // Internal sub-drawers
@@ -52,13 +56,14 @@ function closeAfterLinkClick(link, onClose) {
         },
     });
 }
-function ModuleDrawer({ open, onClose, module, }) {
-    if (!module)
+function ModuleDrawer({ open, onClose, module, renderCtx, }) {
+    const items = module?.items ?? [];
+    if (!module || (items.length === 0 && !module.render))
         return null;
-    return (_jsx(Drawer, { open: open, onOpenChange: (o) => !o && onClose(), direction: "left", children: _jsxs(DrawerContent, { children: [_jsxs(DrawerHeader, { children: [_jsx(DrawerTitle, { children: module.label }), module.description && (_jsx(DrawerDescription, { className: "text-muted-foreground text-xs", children: module.description }))] }), _jsx("nav", { className: "flex flex-col gap-0.5 p-2", children: module.items.map((item) => {
+    return (_jsx(Drawer, { open: open, onOpenChange: (o) => !o && onClose(), direction: "left", children: _jsxs(DrawerContent, { children: [_jsxs(DrawerHeader, { children: [_jsx(DrawerTitle, { children: module.label }), module.description && (_jsx(DrawerDescription, { className: "text-muted-foreground text-xs", children: module.description }))] }), items.length > 0 && (_jsx("nav", { className: "flex flex-col gap-0.5 p-2", children: items.map((item) => {
                         const Icon = item.icon;
                         return (_jsxs("a", { href: item.to, onClick: onClose, className: "flex items-center gap-2 rounded-md px-3 py-2 text-sm text-muted-foreground hover:bg-accent hover:text-foreground", children: [_jsx(Icon, { size: 16, "aria-hidden": "true" }), _jsx("span", { children: item.label })] }, item.id));
-                    }) })] }) }));
+                    }) })), module.render?.(renderCtx)] }) }));
 }
 function PanelsDrawer({ open, onClose, panelViews, defaultView, renderCtx, }) {
     const ctx = useMedaShell();

--- a/dist/shell/panel-views-provider.d.ts
+++ b/dist/shell/panel-views-provider.d.ts
@@ -1,0 +1,15 @@
+import { type ReactNode } from 'react';
+import { type PanelViewRegistration } from './shell-provider.js';
+import type { PanelView } from './types.js';
+export interface PanelViewsProviderProps {
+    views: PanelView[];
+    defaultView?: string;
+    children: ReactNode;
+}
+export interface ResolvedPanelViews {
+    panelViews: PanelView[];
+    defaultView?: string;
+}
+export declare function mergePanelViews(staticViews: PanelView[] | undefined, registrations: PanelViewRegistration[], staticDefaultView?: string): ResolvedPanelViews;
+export declare function useResolvedPanelViews(staticViews?: PanelView[], staticDefaultView?: string): ResolvedPanelViews;
+export declare function PanelViewsProvider({ views, defaultView, children }: PanelViewsProviderProps): import("react/jsx-runtime").JSX.Element;

--- a/dist/shell/panel-views-provider.js
+++ b/dist/shell/panel-views-provider.js
@@ -1,6 +1,6 @@
 'use client';
 import { Fragment as _Fragment, jsx as _jsx } from "react/jsx-runtime";
-import { useId, useLayoutEffect, useMemo } from 'react';
+import { useId, useLayoutEffect, useMemo, useRef } from 'react';
 import { useMedaShell } from './shell-provider.js';
 export function mergePanelViews(staticViews = [], registrations, staticDefaultView) {
     const panelViews = [];
@@ -26,11 +26,31 @@ export function useResolvedPanelViews(staticViews = [], staticDefaultView) {
     const { panelViews } = useMedaShell();
     return useMemo(() => mergePanelViews(staticViews, panelViews.registrations, staticDefaultView), [staticViews, panelViews.registrations, staticDefaultView]);
 }
+function getPanelViewsSignature(views) {
+    return views.map((view) => `${view.id}\u001f${view.label}`).join('\u001e');
+}
 export function PanelViewsProvider({ views, defaultView, children }) {
     const { register } = useMedaShell().panelViews;
     const registrationId = useId();
+    const latestViewsRef = useRef(views);
+    latestViewsRef.current = views;
+    const viewsSignature = getPanelViewsSignature(views);
+    const registeredViewsRef = useRef(null);
+    if (registeredViewsRef.current?.signature !== viewsSignature) {
+        registeredViewsRef.current = {
+            signature: viewsSignature,
+            views: views.map((view) => ({
+                id: view.id,
+                label: view.label,
+                icon: view.icon,
+                render: (ctx) => latestViewsRef.current.find((currentView) => currentView.id === view.id)?.render(ctx) ??
+                    null,
+            })),
+        };
+    }
+    const registeredViews = registeredViewsRef.current.views;
     useLayoutEffect(() => {
-        return register(registrationId, views, defaultView);
-    }, [register, registrationId, views, defaultView]);
+        return register(registrationId, registeredViews, defaultView);
+    }, [register, registrationId, registeredViews, defaultView]);
     return _jsx(_Fragment, { children: children });
 }

--- a/dist/shell/panel-views-provider.js
+++ b/dist/shell/panel-views-provider.js
@@ -1,0 +1,36 @@
+'use client';
+import { Fragment as _Fragment, jsx as _jsx } from "react/jsx-runtime";
+import { useId, useLayoutEffect, useMemo } from 'react';
+import { useMedaShell } from './shell-provider.js';
+export function mergePanelViews(staticViews = [], registrations, staticDefaultView) {
+    const panelViews = [];
+    for (const view of staticViews) {
+        panelViews.push(view);
+    }
+    let defaultView = staticDefaultView;
+    for (const registration of registrations) {
+        for (const view of registration.views) {
+            const previousIndex = panelViews.findIndex((existingView) => existingView.id === view.id);
+            if (previousIndex >= 0) {
+                panelViews.splice(previousIndex, 1);
+            }
+            panelViews.push(view);
+        }
+        if (registration.defaultView !== undefined) {
+            defaultView = registration.defaultView;
+        }
+    }
+    return defaultView === undefined ? { panelViews } : { panelViews, defaultView };
+}
+export function useResolvedPanelViews(staticViews = [], staticDefaultView) {
+    const { panelViews } = useMedaShell();
+    return useMemo(() => mergePanelViews(staticViews, panelViews.registrations, staticDefaultView), [staticViews, panelViews.registrations, staticDefaultView]);
+}
+export function PanelViewsProvider({ views, defaultView, children }) {
+    const { register } = useMedaShell().panelViews;
+    const registrationId = useId();
+    useLayoutEffect(() => {
+        return register(registrationId, views, defaultView);
+    }, [register, registrationId, views, defaultView]);
+    return _jsx(_Fragment, { children: children });
+}

--- a/dist/shell/right-panel.js
+++ b/dist/shell/right-panel.js
@@ -18,6 +18,7 @@ import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
 import { Maximize2, Minimize2, X } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { cn } from '../lib/utils.js';
+import { useResolvedPanelViews } from './panel-views-provider.js';
 import { useMedaShell } from './shell-provider.js';
 import { useShellViewport } from './use-shell-viewport.js';
 // ---------------------------------------------------------------------------
@@ -25,6 +26,7 @@ import { useShellViewport } from './use-shell-viewport.js';
 // ---------------------------------------------------------------------------
 const MIN_WIDTH = 300;
 const MAX_WIDTH = 520;
+const EMPTY_PANEL_VIEWS = [];
 function ResizeHandle({ currentWidth, onResize, onCommit }) {
     const startWidthRef = useRef(currentWidth);
     const startXRef = useRef(0);
@@ -61,17 +63,28 @@ function ResizeHandle({ currentWidth, onResize, onCommit }) {
 // ---------------------------------------------------------------------------
 // RightPanel
 // ---------------------------------------------------------------------------
-export function RightPanel({ panelViews = [], defaultView, modes = ['panel', 'expanded', 'fullscreen'], className, }) {
+export function RightPanel({ panelViews = EMPTY_PANEL_VIEWS, defaultView, modes = ['panel', 'expanded', 'fullscreen'], className, }) {
     const band = useShellViewport();
     const ctx = useMedaShell();
     const { mode, activeView, width, setMode, setActiveView, setWidth } = ctx.panel;
-    // Hydrate defaultView on mount if no active view set
-    // biome-ignore lint/correctness/useExhaustiveDependencies: intentional one-time mount effect
+    const { panelViews: resolvedPanelViews, defaultView: resolvedDefaultView } = useResolvedPanelViews(panelViews, defaultView);
+    const hydratedDefaultRef = useRef(null);
+    // Hydrate a default when static or route-registered views become available.
     useEffect(() => {
-        if (!activeView && defaultView) {
-            setActiveView(defaultView);
+        const defaultExists = resolvedDefaultView != null &&
+            resolvedPanelViews.some((view) => view.id === resolvedDefaultView);
+        if (!defaultExists)
+            return;
+        const source = resolvedDefaultView !== defaultView ? 'registered' : 'static';
+        const canReplaceStaticDefault = activeView === hydratedDefaultRef.current?.id &&
+            hydratedDefaultRef.current.source === 'static' &&
+            source === 'registered' &&
+            activeView !== resolvedDefaultView;
+        if (!activeView || canReplaceStaticDefault) {
+            hydratedDefaultRef.current = { id: resolvedDefaultView, source };
+            setActiveView(resolvedDefaultView);
         }
-    }, []);
+    }, [activeView, defaultView, resolvedDefaultView, resolvedPanelViews, setActiveView]);
     // Local display width tracks pointer-move updates live;
     // setWidth (persist) is called on pointerUp.
     const [displayWidth, setDisplayWidth] = useState(null);
@@ -109,14 +122,14 @@ export function RightPanel({ panelViews = [], defaultView, modes = ['panel', 'ex
     })();
     // Z-index escalation: fullscreen covers header + rails
     const zIndexClass = mode === 'fullscreen' ? 'z-[var(--z-shell-fullscreen)]' : 'z-[var(--z-shell-panel)]';
-    const activePanelView = panelViews.find((v) => v.id === activeView);
+    const activePanelView = resolvedPanelViews.find((v) => v.id === activeView);
     const cycleAriaLabel = mode === 'panel' ? 'Expand panel' : mode === 'expanded' ? 'Maximize panel' : 'Restore panel';
     const handleResize = (w) => setDisplayWidth(w);
     const handleCommit = (w) => {
         setDisplayWidth(null);
         setWidth(w);
     };
-    return (_jsx("aside", { "data-meda-panel-mode": mode, "aria-hidden": mode === 'closed' ? 'true' : undefined, className: cn('relative h-full shrink-0 overflow-hidden border-l border-shell-border bg-shell-panel', 'transition-[width] ease-[var(--motion-ease)] duration-[var(--motion-panel)]', mode === 'fullscreen' && 'fixed inset-0 h-screen w-screen border-none', zIndexClass, className), style: widthStyle, children: mode !== 'closed' && (_jsxs("div", { className: "flex h-full flex-col", children: [_jsxs("div", { className: "flex items-center justify-between border-b border-shell-border px-3 py-2", children: [_jsx("div", { className: "flex items-center gap-1", children: panelViews.map((view) => {
+    return (_jsx("aside", { "data-meda-panel-mode": mode, "aria-hidden": mode === 'closed' ? 'true' : undefined, className: cn('relative h-full shrink-0 overflow-hidden border-l border-shell-border bg-shell-panel', 'transition-[width] ease-[var(--motion-ease)] duration-[var(--motion-panel)]', mode === 'fullscreen' && 'fixed inset-0 h-screen w-screen border-none', zIndexClass, className), style: widthStyle, children: mode !== 'closed' && (_jsxs("div", { className: "flex h-full flex-col", children: [_jsxs("div", { className: "flex items-center justify-between border-b border-shell-border px-3 py-2", children: [_jsx("div", { className: "flex items-center gap-1", children: resolvedPanelViews.map((view) => {
                                 const isActive = view.id === activeView;
                                 const Icon = view.icon;
                                 return (_jsxs("button", { type: "button", "aria-current": isActive ? 'true' : undefined, onClick: () => setActiveView(view.id), className: cn('inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium transition-colors', isActive

--- a/dist/shell/shell-provider.d.ts
+++ b/dist/shell/shell-provider.d.ts
@@ -1,7 +1,12 @@
 import { type ReactNode } from 'react';
 import { type ShellStorageAdapter } from './layout-state.js';
-import type { AppDefinition, MobileBottomNavItem, PanelMode, ThemeAdapter, WorkspaceDefinition } from './types.js';
+import type { AppDefinition, MobileBottomNavItem, PanelMode, PanelView, ThemeAdapter, WorkspaceDefinition } from './types.js';
 export type MobileDrawerKind = 'menu-drawer' | 'module-drawer' | 'panels-drawer' | 'ai-drawer' | (string & {}) | null;
+export interface PanelViewRegistration {
+    id: string;
+    views: PanelView[];
+    defaultView?: string;
+}
 interface MedaShellContextValue {
     workspace: WorkspaceDefinition;
     workspaces: WorkspaceDefinition[];
@@ -39,6 +44,10 @@ interface MedaShellContextValue {
     commandPalette: {
         open: boolean;
         setOpen: (open: boolean) => void;
+    };
+    panelViews: {
+        registrations: PanelViewRegistration[];
+        register: (id: string, views: PanelView[], defaultView?: string) => () => void;
     };
     commandPaletteHotkey: string;
     /** Selection bridge between main workspace and right panel views (spec §17). */

--- a/dist/shell/shell-provider.js
+++ b/dist/shell/shell-provider.js
@@ -1,7 +1,7 @@
 'use client';
 import { jsx as _jsx } from "react/jsx-runtime";
 import { LayoutGrid, Menu, PanelTop, Sparkles } from 'lucide-react';
-import { createContext, lazy, Suspense, useContext, useMemo, useState, } from 'react';
+import { createContext, lazy, Suspense, useCallback, useContext, useMemo, useState, } from 'react';
 import { createLocalStorageAdapter, useShellLayoutState, } from './layout-state.js';
 import { DefaultThemeProvider, ThemeCtx } from './theme.js';
 import { useShellViewport } from './use-shell-viewport.js';
@@ -79,6 +79,29 @@ export function MedaShellProvider(props) {
         open: commandPaletteOpen,
         setOpen: setCommandPaletteOpen,
     }), [commandPaletteOpen]);
+    const [panelViewRegistrations, setPanelViewRegistrations] = useState([]);
+    const registerPanelViews = useCallback((id, views, defaultView) => {
+        setPanelViewRegistrations((prev) => {
+            const existing = prev.find((registration) => registration.id === id);
+            if (existing?.views === views && existing.defaultView === defaultView)
+                return prev;
+            const nextRegistration = defaultView === undefined ? { id, views } : { id, views, defaultView };
+            if (existing == null)
+                return [...prev, nextRegistration];
+            return prev.map((registration) => (registration.id === id ? nextRegistration : registration));
+        });
+        return () => {
+            setPanelViewRegistrations((prev) => prev.some((registration) => registration.id === id &&
+                registration.views === views &&
+                registration.defaultView === defaultView)
+                ? prev.filter((registration) => registration.id !== id)
+                : prev);
+        };
+    }, []);
+    const panelViews = useMemo(() => ({
+        registrations: panelViewRegistrations,
+        register: registerPanelViews,
+    }), [panelViewRegistrations, registerPanelViews]);
     const [layoutState, setLayoutState] = useShellLayoutState({
         workspaceId: props.workspace.id,
         appId: activeAppId,
@@ -169,6 +192,7 @@ export function MedaShellProvider(props) {
         mobileBottomNav: props.mobileBottomNav ?? defaultMobileBottomNav,
         mobileDrawer,
         commandPalette,
+        panelViews,
         commandPaletteHotkey: props.commandPaletteHotkey ?? 'mod+k',
         selection,
         setSelection,
@@ -182,6 +206,7 @@ export function MedaShellProvider(props) {
         props.mobileBottomNav,
         mobileDrawer,
         commandPalette,
+        panelViews,
         props.commandPaletteHotkey,
         selection,
     ]);

--- a/dist/shell/types.d.ts
+++ b/dist/shell/types.d.ts
@@ -14,7 +14,8 @@ export interface ContextModule {
     id: string;
     label: string;
     description?: string;
-    items: ContextItem[];
+    items?: ContextItem[];
+    render?: (ctx: ShellRenderContext) => ReactNode;
 }
 export interface ContextItem {
     id: string;

--- a/src/shell/app-shell-workspace.test.tsx
+++ b/src/shell/app-shell-workspace.test.tsx
@@ -141,4 +141,90 @@ describe('AppShellWorkspace', () => {
     expect(navigate).toHaveBeenCalledWith('/i');
     expect(screen.getByTestId('mobile-drawer-state')).toHaveTextContent('closed');
   });
+
+  it('renders mobile context module custom content with the context rail app id', () => {
+    (useShellViewport as ReturnType<typeof vi.fn>).mockReturnValue('mobile');
+
+    render(
+      <Provider>
+        <AppShellWorkspace
+          iconRail={config.iconRail}
+          contextRail={{
+            appId: 'context-app',
+            module: {
+              id: 'custom-module',
+              label: 'Custom Module',
+              render: ({ workspaceId, appId }) => (
+                <section data-testid="mobile-module-custom-content">
+                  {workspaceId}:{appId}
+                </section>
+              ),
+            },
+          }}
+        >
+          <main aria-label="content">hi</main>
+        </AppShellWorkspace>
+      </Provider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Module' }));
+
+    expect(screen.getByTestId('mobile-module-custom-content')).toHaveTextContent('w:context-app');
+    expect(screen.queryAllByRole('link')).toHaveLength(0);
+  });
+
+  it('renders mobile context module items before custom content', () => {
+    (useShellViewport as ReturnType<typeof vi.fn>).mockReturnValue('mobile');
+
+    render(
+      <Provider>
+        <AppShellWorkspace
+          iconRail={config.iconRail}
+          contextRail={{
+            appId: 'context-app',
+            module: {
+              ...config.contextRail.module,
+              render: () => (
+                <section data-testid="mobile-module-custom-content">Conversation list</section>
+              ),
+            },
+          }}
+        >
+          <main aria-label="content">hi</main>
+        </AppShellWorkspace>
+      </Provider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Module' }));
+
+    const moduleLink = screen.getByRole('link', { name: 'Inbox' });
+    const customContent = screen.getByTestId('mobile-module-custom-content');
+    expect(
+      moduleLink.compareDocumentPosition(customContent) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
+  it.each([
+    { id: 'empty-module', label: 'Empty Module' },
+    { id: 'empty-items-module', label: 'Empty Items Module', items: [] },
+  ])('does not render a mobile Module nav item for empty module %#', (module) => {
+    (useShellViewport as ReturnType<typeof vi.fn>).mockReturnValue('mobile');
+
+    render(
+      <Provider>
+        <AppShellWorkspace
+          iconRail={config.iconRail}
+          contextRail={{
+            appId: 'context-app',
+            module,
+          }}
+        >
+          <main aria-label="content">hi</main>
+        </AppShellWorkspace>
+      </Provider>
+    );
+
+    expect(screen.getByRole('button', { name: 'Menu' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Module' })).not.toBeInTheDocument();
+  });
 });

--- a/src/shell/app-shell-workspace.test.tsx
+++ b/src/shell/app-shell-workspace.test.tsx
@@ -7,6 +7,7 @@ vi.mock('./use-shell-viewport.js', () => ({
 }));
 
 import { AppShellWorkspace } from './app-shell-workspace.js';
+import { PanelViewsProvider } from './panel-views-provider.js';
 import { MedaShellProvider, useMedaShell } from './shell-provider.js';
 import { useShellViewport } from './use-shell-viewport.js';
 
@@ -42,6 +43,29 @@ function MobileDrawerStateProbe() {
   return <output data-testid="mobile-drawer-state">{ctx.mobileDrawer.open ?? 'closed'}</output>;
 }
 
+const routePanelViews = [
+  {
+    id: 'route-inspector',
+    label: 'Route Inspector',
+    icon: Inbox,
+    render: () => <section>Route inspector content</section>,
+  },
+  {
+    id: 'route-activity',
+    label: 'Route Activity',
+    icon: Inbox,
+    render: () => <section>Route activity content</section>,
+  },
+];
+
+const openPanelStorage = {
+  load: () => ({
+    contextRail: { width: 260, collapsed: false },
+    rightPanel: { mode: 'panel', activeView: null, width: 340 },
+  }),
+  save: () => {},
+};
+
 describe('AppShellWorkspace', () => {
   it('renders desktop chrome (icon rail + context rail + right panel) on desktop', () => {
     (useShellViewport as ReturnType<typeof vi.fn>).mockReturnValue('desktop');
@@ -57,6 +81,33 @@ describe('AppShellWorkspace', () => {
     expect(screen.queryByTestId('mobile-bottom-nav')).not.toBeInTheDocument();
   });
 
+  it('renders desktop right panel tabs from route-registered panel views without static rightPanel config', async () => {
+    (useShellViewport as ReturnType<typeof vi.fn>).mockReturnValue('desktop');
+
+    render(
+      <MedaShellProvider
+        workspace={{ id: 'w', name: 'W', icon: null }}
+        workspaces={[{ id: 'w', name: 'W', icon: null }]}
+        apps={[{ id: 'a', label: 'A', icon: Inbox }]}
+        storage={openPanelStorage}
+        themeAdapter="default"
+      >
+        <AppShellWorkspace>
+          <PanelViewsProvider views={routePanelViews} defaultView="route-activity">
+            <main aria-label="content">hi</main>
+          </PanelViewsProvider>
+        </AppShellWorkspace>
+      </MedaShellProvider>
+    );
+
+    expect(await screen.findByRole('button', { name: 'Route Inspector' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Route Activity' })).toHaveAttribute(
+      'aria-current',
+      'true'
+    );
+    expect(screen.getByText('Route activity content')).toBeInTheDocument();
+  });
+
   it('renders mobile chrome (header + bottom nav + drawers) on mobile', () => {
     (useShellViewport as ReturnType<typeof vi.fn>).mockReturnValue('mobile');
     render(
@@ -69,6 +120,65 @@ describe('AppShellWorkspace', () => {
     expect(screen.queryByTestId('icon-rail')).not.toBeInTheDocument();
     expect(screen.getByTestId('mobile-header')).toBeInTheDocument();
     expect(screen.getByTestId('mobile-bottom-nav')).toBeInTheDocument();
+  });
+
+  it('renders mobile Panels nav and drawer content from route-registered panel views without static rightPanel config', async () => {
+    (useShellViewport as ReturnType<typeof vi.fn>).mockReturnValue('mobile');
+
+    render(
+      <Provider>
+        <AppShellWorkspace>
+          <PanelViewsProvider views={routePanelViews} defaultView="route-activity">
+            <main aria-label="content">hi</main>
+          </PanelViewsProvider>
+        </AppShellWorkspace>
+      </Provider>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Panels' }));
+
+    expect(screen.getByRole('button', { name: 'Route Inspector' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Route Activity' })).toHaveAttribute(
+      'aria-current',
+      'true'
+    );
+    expect(screen.getByText('Route activity content')).toBeInTheDocument();
+  });
+
+  it('passes merged static and route-registered panel views into the mobile Panels drawer', async () => {
+    (useShellViewport as ReturnType<typeof vi.fn>).mockReturnValue('mobile');
+
+    render(
+      <Provider>
+        <AppShellWorkspace
+          rightPanel={{
+            panelViews: [
+              {
+                id: 'static-inspector',
+                label: 'Static Inspector',
+                icon: Inbox,
+                render: () => <section>Static inspector content</section>,
+              },
+            ],
+            defaultView: 'static-inspector',
+          }}
+        >
+          <PanelViewsProvider views={routePanelViews} defaultView="route-activity">
+            <main aria-label="content">hi</main>
+          </PanelViewsProvider>
+        </AppShellWorkspace>
+      </Provider>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Panels' }));
+
+    expect(screen.getByRole('button', { name: 'Static Inspector' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Route Inspector' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Route Activity' })).toHaveAttribute(
+      'aria-current',
+      'true'
+    );
+    expect(screen.getByText('Route activity content')).toBeInTheDocument();
   });
 
   it('passes iconRail.renderLink through to IconRail on desktop', () => {

--- a/src/shell/app-shell-workspace.tsx
+++ b/src/shell/app-shell-workspace.tsx
@@ -19,6 +19,8 @@ import type {
 } from './types.js';
 import { useShellViewport } from './use-shell-viewport.js';
 
+const EMPTY_PANEL_VIEWS: PanelView[] = [];
+
 export interface AppShellWorkspaceProps {
   iconRail?: AppShellIconRailConfig;
   contextRail?: AppShellContextRailConfig;
@@ -36,10 +38,8 @@ export function AppShellWorkspace({
 }: AppShellWorkspaceProps) {
   const viewport = useShellViewport();
   const isMobile = viewport === 'mobile';
-  const resolvedRightPanel = useResolvedPanelViews(
-    rightPanel?.panelViews ?? [],
-    rightPanel?.defaultView
-  );
+  const staticPanelViews = rightPanel?.panelViews ?? EMPTY_PANEL_VIEWS;
+  const resolvedRightPanel = useResolvedPanelViews(staticPanelViews, rightPanel?.defaultView);
 
   // Derive the bottom-nav items from the variant config so each button maps
   // to a drawer that actually has content. Without this filter, partial
@@ -89,10 +89,7 @@ export function AppShellWorkspace({
         )}
         <ShellMain layout="workspace">{children}</ShellMain>
         {!isMobile && resolvedRightPanel.panelViews.length > 0 && (
-          <RightPanel
-            panelViews={rightPanel?.panelViews ?? []}
-            defaultView={rightPanel?.defaultView}
-          />
+          <RightPanel panelViews={staticPanelViews} defaultView={rightPanel?.defaultView} />
         )}
       </div>
       {isMobile && hasDrawerContent && <MobileBottomNav items={navItems} />}

--- a/src/shell/app-shell-workspace.tsx
+++ b/src/shell/app-shell-workspace.tsx
@@ -6,6 +6,7 @@ import { IconRail } from './icon-rail.js';
 import { MobileBottomNav } from './internal/mobile-bottom-nav.js';
 import { MobileDrawers } from './internal/mobile-drawers.js';
 import { MobileHeader } from './internal/mobile-header.js';
+import { useResolvedPanelViews } from './panel-views-provider.js';
 import { RightPanel } from './right-panel.js';
 import { ShellHeader } from './shell-header.js';
 import { ShellMain } from './shell-main.js';
@@ -14,6 +15,7 @@ import type {
   AppShellIconRailConfig,
   AppShellRightPanelConfig,
   MobileBottomNavItem,
+  PanelView,
 } from './types.js';
 import { useShellViewport } from './use-shell-viewport.js';
 
@@ -34,12 +36,16 @@ export function AppShellWorkspace({
 }: AppShellWorkspaceProps) {
   const viewport = useShellViewport();
   const isMobile = viewport === 'mobile';
+  const resolvedRightPanel = useResolvedPanelViews(
+    rightPanel?.panelViews ?? [],
+    rightPanel?.defaultView
+  );
 
   // Derive the bottom-nav items from the variant config so each button maps
   // to a drawer that actually has content. Without this filter, partial
   // configs (e.g. iconRail only) would show Module/Panels/AI buttons that
   // dispatch into the void.
-  const navItems = buildMobileNavItems(iconRail, contextRail, rightPanel);
+  const navItems = buildMobileNavItems(iconRail, contextRail, resolvedRightPanel.panelViews);
   const hasDrawerContent = navItems.length > 0;
 
   // Mobile menu drawer needs both main and utility items — desktop IconRail
@@ -82,8 +88,11 @@ export function AppShellWorkspace({
           />
         )}
         <ShellMain layout="workspace">{children}</ShellMain>
-        {!isMobile && rightPanel && (
-          <RightPanel panelViews={rightPanel.panelViews} defaultView={rightPanel.defaultView} />
+        {!isMobile && resolvedRightPanel.panelViews.length > 0 && (
+          <RightPanel
+            panelViews={rightPanel?.panelViews ?? []}
+            defaultView={rightPanel?.defaultView}
+          />
         )}
       </div>
       {isMobile && hasDrawerContent && <MobileBottomNav items={navItems} />}
@@ -94,8 +103,8 @@ export function AppShellWorkspace({
           menuRenderLink={iconRail?.renderLink}
           module={contextRail?.module}
           moduleAppId={contextRail?.appId}
-          panelViews={rightPanel?.panelViews ?? []}
-          defaultView={rightPanel?.defaultView}
+          panelViews={resolvedRightPanel.panelViews}
+          defaultView={resolvedRightPanel.defaultView}
         />
       )}
     </div>
@@ -105,7 +114,7 @@ export function AppShellWorkspace({
 function buildMobileNavItems(
   iconRail: AppShellIconRailConfig | undefined,
   contextRail: AppShellContextRailConfig | undefined,
-  rightPanel: AppShellRightPanelConfig | undefined
+  panelViews: PanelView[]
 ): MobileBottomNavItem[] {
   const items: MobileBottomNavItem[] = [];
   if (iconRail) {
@@ -119,9 +128,9 @@ function buildMobileNavItems(
   }
   // Panels button only when there's an actual view to render — empty
   // panelViews would open an empty drawer (dead-end tap).
-  if (rightPanel && rightPanel.panelViews.length > 0) {
+  if (panelViews.length > 0) {
     items.push({ id: 'panels', label: 'Panels', icon: PanelTop, opens: 'panels-drawer' });
-    if (rightPanel.panelViews.some((v) => v.id === 'ai')) {
+    if (panelViews.some((v) => v.id === 'ai')) {
       items.push({ id: 'ai', label: 'AI', icon: Sparkles, opens: 'ai-drawer' });
     }
   }

--- a/src/shell/app-shell-workspace.tsx
+++ b/src/shell/app-shell-workspace.tsx
@@ -93,6 +93,7 @@ export function AppShellWorkspace({
           menuActiveId={iconRail?.activeId}
           menuRenderLink={iconRail?.renderLink}
           module={contextRail?.module}
+          moduleAppId={contextRail?.appId}
           panelViews={rightPanel?.panelViews ?? []}
           defaultView={rightPanel?.defaultView}
         />
@@ -110,7 +111,10 @@ function buildMobileNavItems(
   if (iconRail) {
     items.push({ id: 'menu', label: 'Menu', icon: Menu, opens: 'menu-drawer' });
   }
-  if (contextRail?.module) {
+  if (
+    contextRail?.module &&
+    ((contextRail.module.items ?? []).length > 0 || Boolean(contextRail.module.render))
+  ) {
     items.push({ id: 'module', label: 'Module', icon: LayoutGrid, opens: 'module-drawer' });
   }
   // Panels button only when there's an actual view to render — empty

--- a/src/shell/app-shell.stories.tsx
+++ b/src/shell/app-shell.stories.tsx
@@ -12,6 +12,7 @@ import {
 } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { AppShell } from './app-shell.js';
+import { PanelViewsProvider } from './panel-views-provider.js';
 import { MedaShellProvider, useMedaShell } from './shell-provider.js';
 import type {
   AppDefinition,
@@ -45,6 +46,17 @@ const INBOX_MODULE: ContextModule = {
   description: 'Mail + drafts',
   items: INBOX_ITEMS,
 };
+const DYNAMIC_INBOX_MODULE: ContextModule = {
+  ...INBOX_MODULE,
+  render: () => (
+    <div className="border-t border-border px-3 py-4">
+      <p className="text-xs font-medium uppercase text-muted-foreground">Conversation queue</p>
+      <div className="mt-2 rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground">
+        6 priority conversations
+      </div>
+    </div>
+  ),
+};
 const PANEL_VIEWS: PanelView[] = [
   {
     id: 'inspector',
@@ -62,6 +74,16 @@ const PANEL_VIEWS: PanelView[] = [
     label: 'Activity',
     icon: Activity,
     render: () => <div className="p-4 text-sm text-muted-foreground">Activity</div>,
+  },
+];
+const ROUTE_PANEL_VIEWS: PanelView[] = [
+  {
+    id: 'conversation',
+    label: 'Conversation',
+    icon: Mail,
+    render: () => (
+      <div className="p-4 text-sm text-muted-foreground">Route-owned conversation details.</div>
+    ),
   },
 ];
 
@@ -250,10 +272,12 @@ export const WorkspaceWithAdoptionHooks: Story = {
           </a>
         ),
       }}
-      contextRail={{ appId: 'inbox', module: INBOX_MODULE, activeItemId: 'inbox' }}
+      contextRail={{ appId: 'inbox', module: DYNAMIC_INBOX_MODULE, activeItemId: 'inbox' }}
       rightPanel={{ panelViews: PANEL_VIEWS, defaultView: 'inspector' }}
     >
-      <AdoptionControlPanel />
+      <PanelViewsProvider views={ROUTE_PANEL_VIEWS} defaultView="conversation">
+        <AdoptionControlPanel />
+      </PanelViewsProvider>
     </AppShell>
   ),
 };

--- a/src/shell/context-rail.test.tsx
+++ b/src/shell/context-rail.test.tsx
@@ -118,6 +118,18 @@ describe('ContextRail — layout + visibility', () => {
     expect(empty).toHaveAttribute('aria-hidden', 'true');
   });
 
+  it('module without items or custom render renders hidden placeholder, no aside', () => {
+    render(
+      <Wrapper>
+        <ContextRail appId="mail" module={{ id: 'mail', label: 'Mail' }} />
+      </Wrapper>
+    );
+
+    expect(screen.queryByRole('complementary')).not.toBeInTheDocument();
+    const empty = document.querySelector('[data-testid="context-rail-empty"]');
+    expect(empty).toHaveAttribute('aria-hidden', 'true');
+  });
+
   it('no module prop renders hidden placeholder, no aside', () => {
     render(
       <Wrapper>
@@ -227,6 +239,46 @@ describe('ContextRail — resize clamping', () => {
 // ---------------------------------------------------------------------------
 
 describe('ContextRail — module items rendering', () => {
+  it('renders module.render custom content without items and passes shell render context', () => {
+    render(
+      <Wrapper>
+        <ContextRail
+          appId="mail"
+          module={{
+            id: 'mail',
+            label: 'Mail',
+            render: ({ workspaceId, appId }) => (
+              <section data-testid="module-custom-content">
+                {workspaceId}:{appId}
+              </section>
+            ),
+          }}
+        />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('module-custom-content')).toHaveTextContent('ws-test:mail');
+    expect(screen.queryAllByRole('link')).toHaveLength(0);
+  });
+
+  it('renders items before custom module content when both are supplied', () => {
+    render(
+      <Wrapper>
+        <ContextRail
+          appId="mail"
+          module={{
+            ...MODULE,
+            render: () => <section data-testid="module-custom-content">Custom tools</section>,
+          }}
+        />
+      </Wrapper>
+    );
+
+    const nav = screen.getByRole('navigation', { name: 'Mail navigation' });
+    const custom = screen.getByTestId('module-custom-content');
+    expect(nav.compareDocumentPosition(custom) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
   it('renders module title + description in header', () => {
     render(
       <Wrapper>

--- a/src/shell/context-rail.tsx
+++ b/src/shell/context-rail.tsx
@@ -158,7 +158,7 @@ function ContextRailToggle({ railId }: { railId: string }) {
 // ---------------------------------------------------------------------------
 
 export function ContextRail({
-  appId: _appId,
+  appId,
   module,
   hidden = false,
   collapsible = true,
@@ -182,6 +182,7 @@ export function ContextRail({
   // is called on pointerUp to persist via useShellLayoutState.
   const [displayWidth, setDisplayWidth] = useState<number | null>(null);
   const width = displayWidth ?? ctx.contextRail.width;
+  const items = module?.items ?? [];
 
   if (band === 'mobile') return null;
 
@@ -189,7 +190,7 @@ export function ContextRail({
     return <div aria-hidden="true" className="hidden" data-testid="context-rail-hidden" />;
   }
 
-  if (!module || module.items.length === 0) {
+  if (!module || (items.length === 0 && !module.render)) {
     return <div aria-hidden="true" className="hidden" data-testid="context-rail-empty" />;
   }
 
@@ -245,44 +246,46 @@ export function ContextRail({
           )}
         </div>
 
-        {/* Items list — fleshed out in Phase 9.2 (Commit 3) */}
-        <nav aria-label={`${module.label} navigation`} className="flex flex-col gap-0.5 p-2">
-          {module.items.map((item) => {
-            const isActive = item.id === activeItemId;
-            const klass = cn(
-              'flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors',
-              isActive
-                ? 'bg-primary/10 text-primary'
-                : 'text-muted-foreground hover:bg-accent hover:text-foreground'
-            );
-            const IconComp = item.icon;
-            const inner = (
-              <>
-                <IconComp size={16} aria-hidden="true" className="shrink-0" />
-                <span className="truncate">{item.label}</span>
-                {item.shortcut && (
-                  <kbd className="ml-auto font-mono text-[10px] text-muted-foreground">
-                    {item.shortcut}
-                  </kbd>
-                )}
-              </>
-            );
+        {items.length > 0 && (
+          <nav aria-label={`${module.label} navigation`} className="flex flex-col gap-0.5 p-2">
+            {items.map((item) => {
+              const isActive = item.id === activeItemId;
+              const klass = cn(
+                'flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors',
+                isActive
+                  ? 'bg-primary/10 text-primary'
+                  : 'text-muted-foreground hover:bg-accent hover:text-foreground'
+              );
+              const IconComp = item.icon;
+              const inner = (
+                <>
+                  <IconComp size={16} aria-hidden="true" className="shrink-0" />
+                  <span className="truncate">{item.label}</span>
+                  {item.shortcut && (
+                    <kbd className="ml-auto font-mono text-[10px] text-muted-foreground">
+                      {item.shortcut}
+                    </kbd>
+                  )}
+                </>
+              );
 
-            if (renderLink) {
-              return renderLink({ item, isActive, className: klass, children: inner });
-            }
-            return (
-              <a
-                key={item.id}
-                href={item.to}
-                aria-current={isActive ? 'page' : undefined}
-                className={klass}
-              >
-                {inner}
-              </a>
-            );
-          })}
-        </nav>
+              if (renderLink) {
+                return renderLink({ item, isActive, className: klass, children: inner });
+              }
+              return (
+                <a
+                  key={item.id}
+                  href={item.to}
+                  aria-current={isActive ? 'page' : undefined}
+                  className={klass}
+                >
+                  {inner}
+                </a>
+              );
+            })}
+          </nav>
+        )}
+        {module.render?.({ workspaceId: ctx.workspace.id, appId })}
       </div>
 
       {/* Right-edge resize handle — only when expanded (no rail edge to grab when collapsed) */}

--- a/src/shell/index.ts
+++ b/src/shell/index.ts
@@ -22,6 +22,8 @@ export type { ShellStorageAdapter } from './layout-state.js';
 export { createLocalStorageAdapter } from './layout-state.js';
 // Hooks + tokens
 export { motion } from './motion.js';
+export type { PanelViewsProviderProps } from './panel-views-provider.js';
+export { PanelViewsProvider } from './panel-views-provider.js';
 export type { RailDropSlotProps, RailDropSlotState } from './rail-drop-slot.js';
 // Resize primitives
 export { RailDropSlot } from './rail-drop-slot.js';

--- a/src/shell/internal/mobile-drawers.tsx
+++ b/src/shell/internal/mobile-drawers.tsx
@@ -22,6 +22,8 @@ export interface MobileDrawersProps {
   menuRenderLink?: IconRailProps['renderLink'];
   /** Module drawer source (current app's context-rail module). */
   module?: ContextModule;
+  /** App id used when rendering module custom content. */
+  moduleAppId?: string;
   /** Panels drawer source. */
   panelViews?: PanelView[];
   /**
@@ -45,6 +47,7 @@ export function MobileDrawers({
   menuActiveId,
   menuRenderLink,
   module,
+  moduleAppId,
   panelViews = [],
   defaultView,
   customContent = {},
@@ -57,6 +60,10 @@ export function MobileDrawers({
     workspaceId: ctx.workspace.id,
     appId: ctx.activeAppId,
   };
+  const moduleRenderCtx: ShellRenderContext = {
+    workspaceId: ctx.workspace.id,
+    appId: moduleAppId ?? ctx.activeAppId,
+  };
 
   return (
     <>
@@ -67,7 +74,12 @@ export function MobileDrawers({
         activeId={menuActiveId}
         renderLink={menuRenderLink}
       />
-      <ModuleDrawer open={open === 'module-drawer'} onClose={close} module={module} />
+      <ModuleDrawer
+        open={open === 'module-drawer'}
+        onClose={close}
+        module={module}
+        renderCtx={moduleRenderCtx}
+      />
       <PanelsDrawer
         open={open === 'panels-drawer'}
         onClose={close}
@@ -197,12 +209,15 @@ function ModuleDrawer({
   open,
   onClose,
   module,
+  renderCtx,
 }: {
   open: boolean;
   onClose: () => void;
   module?: ContextModule;
+  renderCtx: ShellRenderContext;
 }) {
-  if (!module) return null;
+  const items = module?.items ?? [];
+  if (!module || (items.length === 0 && !module.render)) return null;
   return (
     <Drawer open={open} onOpenChange={(o) => !o && onClose()} direction="left">
       <DrawerContent>
@@ -214,22 +229,25 @@ function ModuleDrawer({
             </DrawerDescription>
           )}
         </DrawerHeader>
-        <nav className="flex flex-col gap-0.5 p-2">
-          {module.items.map((item) => {
-            const Icon = item.icon;
-            return (
-              <a
-                key={item.id}
-                href={item.to}
-                onClick={onClose}
-                className="flex items-center gap-2 rounded-md px-3 py-2 text-sm text-muted-foreground hover:bg-accent hover:text-foreground"
-              >
-                <Icon size={16} aria-hidden="true" />
-                <span>{item.label}</span>
-              </a>
-            );
-          })}
-        </nav>
+        {items.length > 0 && (
+          <nav className="flex flex-col gap-0.5 p-2">
+            {items.map((item) => {
+              const Icon = item.icon;
+              return (
+                <a
+                  key={item.id}
+                  href={item.to}
+                  onClick={onClose}
+                  className="flex items-center gap-2 rounded-md px-3 py-2 text-sm text-muted-foreground hover:bg-accent hover:text-foreground"
+                >
+                  <Icon size={16} aria-hidden="true" />
+                  <span>{item.label}</span>
+                </a>
+              );
+            })}
+          </nav>
+        )}
+        {module.render?.(renderCtx)}
       </DrawerContent>
     </Drawer>
   );

--- a/src/shell/panel-views-provider.tsx
+++ b/src/shell/panel-views-provider.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { type ReactNode, useId, useLayoutEffect, useMemo } from 'react';
+import { type PanelViewRegistration, useMedaShell } from './shell-provider.js';
+import type { PanelView } from './types.js';
+
+export interface PanelViewsProviderProps {
+  views: PanelView[];
+  defaultView?: string;
+  children: ReactNode;
+}
+
+export interface ResolvedPanelViews {
+  panelViews: PanelView[];
+  defaultView?: string;
+}
+
+export function mergePanelViews(
+  staticViews: PanelView[] = [],
+  registrations: PanelViewRegistration[],
+  staticDefaultView?: string
+): ResolvedPanelViews {
+  const panelViews: PanelView[] = [];
+
+  for (const view of staticViews) {
+    panelViews.push(view);
+  }
+
+  let defaultView = staticDefaultView;
+
+  for (const registration of registrations) {
+    for (const view of registration.views) {
+      const previousIndex = panelViews.findIndex((existingView) => existingView.id === view.id);
+      if (previousIndex >= 0) {
+        panelViews.splice(previousIndex, 1);
+      }
+      panelViews.push(view);
+    }
+    if (registration.defaultView !== undefined) {
+      defaultView = registration.defaultView;
+    }
+  }
+
+  return defaultView === undefined ? { panelViews } : { panelViews, defaultView };
+}
+
+export function useResolvedPanelViews(
+  staticViews: PanelView[] = [],
+  staticDefaultView?: string
+): ResolvedPanelViews {
+  const { panelViews } = useMedaShell();
+
+  return useMemo(
+    () => mergePanelViews(staticViews, panelViews.registrations, staticDefaultView),
+    [staticViews, panelViews.registrations, staticDefaultView]
+  );
+}
+
+export function PanelViewsProvider({ views, defaultView, children }: PanelViewsProviderProps) {
+  const { register } = useMedaShell().panelViews;
+  const registrationId = useId();
+
+  useLayoutEffect(() => {
+    return register(registrationId, views, defaultView);
+  }, [register, registrationId, views, defaultView]);
+
+  return <>{children}</>;
+}

--- a/src/shell/panel-views-provider.tsx
+++ b/src/shell/panel-views-provider.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { type ReactNode, useId, useLayoutEffect, useMemo } from 'react';
+import { type ReactNode, useId, useLayoutEffect, useMemo, useRef } from 'react';
 import { type PanelViewRegistration, useMedaShell } from './shell-provider.js';
-import type { PanelView } from './types.js';
+import type { PanelView, ShellRenderContext } from './types.js';
 
 export interface PanelViewsProviderProps {
   views: PanelView[];
@@ -56,13 +56,36 @@ export function useResolvedPanelViews(
   );
 }
 
+function getPanelViewsSignature(views: PanelView[]): string {
+  return views.map((view) => `${view.id}\u001f${view.label}`).join('\u001e');
+}
+
 export function PanelViewsProvider({ views, defaultView, children }: PanelViewsProviderProps) {
   const { register } = useMedaShell().panelViews;
   const registrationId = useId();
+  const latestViewsRef = useRef(views);
+  latestViewsRef.current = views;
+
+  const viewsSignature = getPanelViewsSignature(views);
+  const registeredViewsRef = useRef<{ signature: string; views: PanelView[] } | null>(null);
+  if (registeredViewsRef.current?.signature !== viewsSignature) {
+    registeredViewsRef.current = {
+      signature: viewsSignature,
+      views: views.map((view) => ({
+        id: view.id,
+        label: view.label,
+        icon: view.icon,
+        render: (ctx: ShellRenderContext) =>
+          latestViewsRef.current.find((currentView) => currentView.id === view.id)?.render(ctx) ??
+          null,
+      })),
+    };
+  }
+  const registeredViews = registeredViewsRef.current.views;
 
   useLayoutEffect(() => {
-    return register(registrationId, views, defaultView);
-  }, [register, registrationId, views, defaultView]);
+    return register(registrationId, registeredViews, defaultView);
+  }, [register, registrationId, registeredViews, defaultView]);
 
   return <>{children}</>;
 }

--- a/src/shell/right-panel.test.tsx
+++ b/src/shell/right-panel.test.tsx
@@ -2,7 +2,9 @@ import '@testing-library/jest-dom/vitest';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { Info } from 'lucide-react';
 import type { ReactNode } from 'react';
+import { StrictMode, useState } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PanelViewsProvider } from './panel-views-provider.js';
 import { RightPanel } from './right-panel.js';
 import { MedaShellProvider, useMedaShell } from './shell-provider.js';
 import type { AppDefinition, PanelMode, PanelView, WorkspaceDefinition } from './types.js';
@@ -386,6 +388,335 @@ describe('RightPanel — panelViews', () => {
       </Wrapper>
     );
 
+    expect(screen.getByText('No panel view selected')).toBeInTheDocument();
+  });
+});
+
+describe('RightPanel — PanelViewsProvider registrations', () => {
+  const routeViews: PanelView[] = [
+    { id: 'route-view', label: 'Route View', icon: Info, render: () => <div>Route content</div> },
+  ];
+
+  it('renders panel views registered by a route child through PanelViewsProvider', () => {
+    render(
+      <Wrapper mode="panel" activeView="route-view">
+        <PanelViewsProvider views={routeViews}>
+          <RightPanel />
+        </PanelViewsProvider>
+      </Wrapper>
+    );
+
+    expect(screen.getByRole('button', { name: /route view/i })).toBeInTheDocument();
+    expect(screen.getByText('Route content')).toBeInTheDocument();
+  });
+
+  it('registered views override static views with the same id', () => {
+    const staticViews: PanelView[] = [
+      {
+        id: 'inspector',
+        label: 'Static Inspector',
+        icon: Info,
+        render: () => <div>Static inspector content</div>,
+      },
+    ];
+    const registeredViews: PanelView[] = [
+      {
+        id: 'inspector',
+        label: 'Registered Inspector',
+        icon: Info,
+        render: () => <div>Registered inspector content</div>,
+      },
+    ];
+
+    render(
+      <Wrapper mode="panel" activeView="inspector">
+        <PanelViewsProvider views={registeredViews}>
+          <RightPanel panelViews={staticViews} />
+        </PanelViewsProvider>
+      </Wrapper>
+    );
+
+    expect(screen.getByRole('button', { name: /registered inspector/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /static inspector/i })).not.toBeInTheDocument();
+    expect(screen.getByText('Registered inspector content')).toBeInTheDocument();
+    expect(screen.queryByText('Static inspector content')).not.toBeInTheDocument();
+  });
+
+  it('places registered overrides after remaining static views', () => {
+    const staticViews: PanelView[] = [
+      {
+        id: 'inspector',
+        label: 'Static Inspector',
+        icon: Info,
+        render: () => <div>Static inspector content</div>,
+      },
+      { id: 'activity', label: 'Activity', icon: Info, render: () => <div>Activity content</div> },
+    ];
+    const registeredViews: PanelView[] = [
+      {
+        id: 'inspector',
+        label: 'Registered Inspector',
+        icon: Info,
+        render: () => <div>Registered inspector content</div>,
+      },
+    ];
+
+    render(
+      <Wrapper mode="panel" activeView="activity">
+        <PanelViewsProvider views={registeredViews}>
+          <RightPanel panelViews={staticViews} />
+        </PanelViewsProvider>
+      </Wrapper>
+    );
+
+    const activityTab = screen.getByRole('button', { name: /activity/i });
+    const registeredTab = screen.getByRole('button', { name: /registered inspector/i });
+    expect(
+      activityTab.compareDocumentPosition(registeredTab) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
+  it('merges views from multiple provider instances without requiring consumer ids', () => {
+    const firstRouteViews: PanelView[] = [
+      { id: 'route-a', label: 'Route A', icon: Info, render: () => <div>Route A content</div> },
+    ];
+    const secondRouteViews: PanelView[] = [
+      { id: 'route-b', label: 'Route B', icon: Info, render: () => <div>Route B content</div> },
+    ];
+
+    render(
+      <Wrapper mode="panel" activeView="route-a">
+        <PanelViewsProvider views={firstRouteViews}>
+          <div />
+        </PanelViewsProvider>
+        <PanelViewsProvider views={secondRouteViews}>
+          <div />
+        </PanelViewsProvider>
+        <RightPanel />
+      </Wrapper>
+    );
+
+    expect(screen.getByRole('button', { name: /route a/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /route b/i })).toBeInTheDocument();
+  });
+
+  it('registered provider defaultView wins over static defaultView and sets active view when no active view exists', async () => {
+    const storage = { load: vi.fn(() => null), save: vi.fn() };
+
+    function Root() {
+      const ctx = useMedaShell();
+      const isPanel = ctx.panel.mode === 'panel';
+      return (
+        <>
+          <button type="button" onClick={() => ctx.panel.setMode('panel')} data-testid="open-panel">
+            Open
+          </button>
+          {isPanel && (
+            <PanelViewsProvider views={routeViews} defaultView="route-view">
+              <RightPanel panelViews={VIEWS} defaultView="activity" />
+            </PanelViewsProvider>
+          )}
+        </>
+      );
+    }
+
+    render(
+      <MedaShellProvider workspace={ws} apps={apps} storage={storage}>
+        <Root />
+      </MedaShellProvider>
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('open-panel'));
+    });
+
+    expect(screen.getByRole('button', { name: /route view/i })).toHaveAttribute(
+      'aria-current',
+      'true'
+    );
+    expect(screen.getByText('Route content')).toBeInTheDocument();
+  });
+
+  it('does not overwrite an existing active view when registered defaultView changes', async () => {
+    const routeViews: PanelView[] = [
+      { id: 'route-a', label: 'Route A', icon: Info, render: () => <div>Route A content</div> },
+      { id: 'route-b', label: 'Route B', icon: Info, render: () => <div>Route B content</div> },
+    ];
+
+    function Root() {
+      const [defaultView, setDefaultView] = useState('route-a');
+      return (
+        <>
+          <button
+            type="button"
+            data-testid="switch-default"
+            onClick={() => setDefaultView('route-b')}
+          >
+            Switch default
+          </button>
+          <PanelViewsProvider views={routeViews} defaultView={defaultView}>
+            <RightPanel />
+          </PanelViewsProvider>
+        </>
+      );
+    }
+
+    render(
+      <Wrapper mode="panel" activeView={null}>
+        <Root />
+      </Wrapper>
+    );
+
+    expect(await screen.findByRole('button', { name: /route a/i })).toHaveAttribute(
+      'aria-current',
+      'true'
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('switch-default'));
+    });
+
+    expect(screen.getByRole('button', { name: /route a/i })).toHaveAttribute(
+      'aria-current',
+      'true'
+    );
+    expect(screen.getByText('Route A content')).toBeInTheDocument();
+  });
+
+  it('does not apply a defaultView id that is not registered', () => {
+    render(
+      <Wrapper mode="panel" activeView={null}>
+        <PanelViewsProvider views={routeViews} defaultView="missing-view">
+          <RightPanel />
+        </PanelViewsProvider>
+      </Wrapper>
+    );
+
+    expect(screen.getByRole('button', { name: /route view/i })).not.toHaveAttribute('aria-current');
+    expect(screen.getByText('No panel view selected')).toBeInTheDocument();
+  });
+
+  it('uses the last registered defaultView when multiple providers supply defaults', async () => {
+    const firstRouteViews: PanelView[] = [
+      { id: 'route-a', label: 'Route A', icon: Info, render: () => <div>Route A content</div> },
+    ];
+    const secondRouteViews: PanelView[] = [
+      { id: 'route-b', label: 'Route B', icon: Info, render: () => <div>Route B content</div> },
+    ];
+
+    render(
+      <Wrapper mode="panel" activeView={null}>
+        <PanelViewsProvider views={firstRouteViews} defaultView="route-a">
+          <div />
+        </PanelViewsProvider>
+        <PanelViewsProvider views={secondRouteViews} defaultView="route-b">
+          <div />
+        </PanelViewsProvider>
+        <RightPanel />
+      </Wrapper>
+    );
+
+    expect(await screen.findByRole('button', { name: /route b/i })).toHaveAttribute(
+      'aria-current',
+      'true'
+    );
+    expect(screen.getByText('Route B content')).toBeInTheDocument();
+  });
+
+  it('replaces stale registrations when provider view props change', async () => {
+    const firstRouteViews: PanelView[] = [
+      { id: 'route-a', label: 'Route A', icon: Info, render: () => <div>Route A content</div> },
+    ];
+    const secondRouteViews: PanelView[] = [
+      { id: 'route-b', label: 'Route B', icon: Info, render: () => <div>Route B content</div> },
+    ];
+
+    function Root() {
+      const [views, setViews] = useState(firstRouteViews);
+      return (
+        <>
+          <button
+            type="button"
+            data-testid="switch-views"
+            onClick={() => setViews(secondRouteViews)}
+          >
+            Switch views
+          </button>
+          <PanelViewsProvider views={views}>
+            <RightPanel />
+          </PanelViewsProvider>
+        </>
+      );
+    }
+
+    render(
+      <Wrapper mode="panel" activeView="route-b">
+        <Root />
+      </Wrapper>
+    );
+
+    expect(screen.getByRole('button', { name: /route a/i })).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('switch-views'));
+    });
+
+    expect(screen.queryByRole('button', { name: /route a/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /route b/i })).toBeInTheDocument();
+    expect(screen.getByText('Route B content')).toBeInTheDocument();
+  });
+
+  it('keeps registered views mounted through React StrictMode effect replay', () => {
+    render(
+      <StrictMode>
+        <Wrapper mode="panel" activeView="route-view">
+          <PanelViewsProvider views={routeViews}>
+            <RightPanel />
+          </PanelViewsProvider>
+        </Wrapper>
+      </StrictMode>
+    );
+
+    expect(screen.getByRole('button', { name: /route view/i })).toBeInTheDocument();
+    expect(screen.getByText('Route content')).toBeInTheDocument();
+  });
+
+  it('registered views unregister on provider unmount and RightPanel falls back to no selected view', async () => {
+    function Root() {
+      const [showRegistered, setShowRegistered] = useState(true);
+      return (
+        <>
+          <button
+            type="button"
+            onClick={() => setShowRegistered(false)}
+            data-testid="unmount-provider"
+          >
+            Unmount
+          </button>
+          {showRegistered ? (
+            <PanelViewsProvider views={routeViews}>
+              <RightPanel />
+            </PanelViewsProvider>
+          ) : (
+            <RightPanel />
+          )}
+        </>
+      );
+    }
+
+    render(
+      <Wrapper mode="panel" activeView="route-view">
+        <Root />
+      </Wrapper>
+    );
+
+    expect(screen.getByText('Route content')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('unmount-provider'));
+    });
+
+    expect(screen.queryByRole('button', { name: /route view/i })).not.toBeInTheDocument();
     expect(screen.getByText('No panel view selected')).toBeInTheDocument();
   });
 });

--- a/src/shell/right-panel.test.tsx
+++ b/src/shell/right-panel.test.tsx
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom/vitest';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { Info } from 'lucide-react';
 import type { ReactNode } from 'react';
-import { StrictMode, useState } from 'react';
+import { StrictMode, useEffect, useRef, useState } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { PanelViewsProvider } from './panel-views-provider.js';
 import { RightPanel } from './right-panel.js';
@@ -679,6 +679,64 @@ describe('RightPanel — PanelViewsProvider registrations', () => {
 
     expect(screen.getByRole('button', { name: /route view/i })).toBeInTheDocument();
     expect(screen.getByText('Route content')).toBeInTheDocument();
+  });
+
+  it('does not re-register equivalent inline view arrays on parent rerender', async () => {
+    function RegistrationChangeProbe() {
+      const ctx = useMedaShell();
+      const registrations = ctx.panelViews.registrations;
+      const previousRegistrations = useRef(registrations);
+      const [changes, setChanges] = useState(0);
+
+      useEffect(() => {
+        if (previousRegistrations.current !== registrations) {
+          previousRegistrations.current = registrations;
+          setChanges((value) => value + 1);
+        }
+      }, [registrations]);
+
+      return <output data-testid="registration-change-count">{changes}</output>;
+    }
+
+    function Root() {
+      const [count, setCount] = useState(0);
+      return (
+        <>
+          <button type="button" data-testid="rerender-route" onClick={() => setCount((n) => n + 1)}>
+            Rerender
+          </button>
+          <RegistrationChangeProbe />
+          <PanelViewsProvider
+            views={[
+              {
+                id: 'route-view',
+                label: 'Route View',
+                icon: Info,
+                render: () => <div>Route content {count}</div>,
+              },
+            ]}
+          >
+            <RightPanel />
+          </PanelViewsProvider>
+        </>
+      );
+    }
+
+    render(
+      <Wrapper mode="panel" activeView="route-view">
+        <Root />
+      </Wrapper>
+    );
+
+    expect(await screen.findByText('Route content 0')).toBeInTheDocument();
+    expect(screen.getByTestId('registration-change-count')).toHaveTextContent('1');
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('rerender-route'));
+    });
+
+    expect(screen.getByText('Route content 1')).toBeInTheDocument();
+    expect(screen.getByTestId('registration-change-count')).toHaveTextContent('1');
   });
 
   it('registered views unregister on provider unmount and RightPanel falls back to no selected view', async () => {

--- a/src/shell/right-panel.tsx
+++ b/src/shell/right-panel.tsx
@@ -19,6 +19,7 @@
 import { Maximize2, Minimize2, X } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { cn } from '../lib/utils.js';
+import { useResolvedPanelViews } from './panel-views-provider.js';
 import { useMedaShell } from './shell-provider.js';
 import type { PanelMode, PanelView, ShellRenderContext } from './types.js';
 import { useShellViewport } from './use-shell-viewport.js';
@@ -29,6 +30,7 @@ import { useShellViewport } from './use-shell-viewport.js';
 
 const MIN_WIDTH = 300;
 const MAX_WIDTH = 520;
+const EMPTY_PANEL_VIEWS: PanelView[] = [];
 
 // ---------------------------------------------------------------------------
 // RightPanelProps
@@ -116,7 +118,7 @@ function ResizeHandle({ currentWidth, onResize, onCommit }: ResizeHandleProps) {
 // ---------------------------------------------------------------------------
 
 export function RightPanel({
-  panelViews = [],
+  panelViews = EMPTY_PANEL_VIEWS,
   defaultView,
   modes = ['panel', 'expanded', 'fullscreen'],
   className,
@@ -124,14 +126,29 @@ export function RightPanel({
   const band = useShellViewport();
   const ctx = useMedaShell();
   const { mode, activeView, width, setMode, setActiveView, setWidth } = ctx.panel;
+  const { panelViews: resolvedPanelViews, defaultView: resolvedDefaultView } =
+    useResolvedPanelViews(panelViews, defaultView);
+  const hydratedDefaultRef = useRef<{ id: string; source: 'static' | 'registered' } | null>(null);
 
-  // Hydrate defaultView on mount if no active view set
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional one-time mount effect
+  // Hydrate a default when static or route-registered views become available.
   useEffect(() => {
-    if (!activeView && defaultView) {
-      setActiveView(defaultView);
+    const defaultExists =
+      resolvedDefaultView != null &&
+      resolvedPanelViews.some((view) => view.id === resolvedDefaultView);
+    if (!defaultExists) return;
+
+    const source = resolvedDefaultView !== defaultView ? 'registered' : 'static';
+    const canReplaceStaticDefault =
+      activeView === hydratedDefaultRef.current?.id &&
+      hydratedDefaultRef.current.source === 'static' &&
+      source === 'registered' &&
+      activeView !== resolvedDefaultView;
+
+    if (!activeView || canReplaceStaticDefault) {
+      hydratedDefaultRef.current = { id: resolvedDefaultView, source };
+      setActiveView(resolvedDefaultView);
     }
-  }, []);
+  }, [activeView, defaultView, resolvedDefaultView, resolvedPanelViews, setActiveView]);
 
   // Local display width tracks pointer-move updates live;
   // setWidth (persist) is called on pointerUp.
@@ -175,7 +192,7 @@ export function RightPanel({
   const zIndexClass =
     mode === 'fullscreen' ? 'z-[var(--z-shell-fullscreen)]' : 'z-[var(--z-shell-panel)]';
 
-  const activePanelView = panelViews.find((v) => v.id === activeView);
+  const activePanelView = resolvedPanelViews.find((v) => v.id === activeView);
 
   const cycleAriaLabel =
     mode === 'panel' ? 'Expand panel' : mode === 'expanded' ? 'Maximize panel' : 'Restore panel';
@@ -205,7 +222,7 @@ export function RightPanel({
           <div className="flex items-center justify-between border-b border-shell-border px-3 py-2">
             {/* View tabs */}
             <div className="flex items-center gap-1">
-              {panelViews.map((view) => {
+              {resolvedPanelViews.map((view) => {
                 const isActive = view.id === activeView;
                 const Icon = view.icon;
                 return (

--- a/src/shell/shell-provider.tsx
+++ b/src/shell/shell-provider.tsx
@@ -6,6 +6,7 @@ import {
   lazy,
   type ReactNode,
   Suspense,
+  useCallback,
   useContext,
   useMemo,
   useState,
@@ -20,6 +21,7 @@ import type {
   AppDefinition,
   MobileBottomNavItem,
   PanelMode,
+  PanelView,
   ThemeAdapter,
   WorkspaceDefinition,
 } from './types.js';
@@ -89,6 +91,12 @@ const defaultMobileBottomNav: MobileBottomNavItem[] = [
 // Context value shape
 // ---------------------------------------------------------------------------
 
+export interface PanelViewRegistration {
+  id: string;
+  views: PanelView[];
+  defaultView?: string;
+}
+
 interface MedaShellContextValue {
   workspace: WorkspaceDefinition;
   workspaces: WorkspaceDefinition[];
@@ -126,6 +134,10 @@ interface MedaShellContextValue {
   commandPalette: {
     open: boolean;
     setOpen: (open: boolean) => void;
+  };
+  panelViews: {
+    registrations: PanelViewRegistration[];
+    register: (id: string, views: PanelView[], defaultView?: string) => () => void;
   };
   commandPaletteHotkey: string;
   /** Selection bridge between main workspace and right panel views (spec §17). */
@@ -205,6 +217,43 @@ export function MedaShellProvider(props: MedaShellProviderProps) {
       setOpen: setCommandPaletteOpen,
     }),
     [commandPaletteOpen]
+  );
+
+  const [panelViewRegistrations, setPanelViewRegistrations] = useState<PanelViewRegistration[]>([]);
+
+  const registerPanelViews = useCallback((id: string, views: PanelView[], defaultView?: string) => {
+    setPanelViewRegistrations((prev) => {
+      const existing = prev.find((registration) => registration.id === id);
+      if (existing?.views === views && existing.defaultView === defaultView) return prev;
+
+      const nextRegistration =
+        defaultView === undefined ? { id, views } : { id, views, defaultView };
+
+      if (existing == null) return [...prev, nextRegistration];
+
+      return prev.map((registration) => (registration.id === id ? nextRegistration : registration));
+    });
+
+    return () => {
+      setPanelViewRegistrations((prev) =>
+        prev.some(
+          (registration) =>
+            registration.id === id &&
+            registration.views === views &&
+            registration.defaultView === defaultView
+        )
+          ? prev.filter((registration) => registration.id !== id)
+          : prev
+      );
+    };
+  }, []);
+
+  const panelViews = useMemo(
+    () => ({
+      registrations: panelViewRegistrations,
+      register: registerPanelViews,
+    }),
+    [panelViewRegistrations, registerPanelViews]
   );
 
   const [layoutState, setLayoutState] = useShellLayoutState({
@@ -313,6 +362,7 @@ export function MedaShellProvider(props: MedaShellProviderProps) {
       mobileBottomNav: props.mobileBottomNav ?? defaultMobileBottomNav,
       mobileDrawer,
       commandPalette,
+      panelViews,
       commandPaletteHotkey: props.commandPaletteHotkey ?? 'mod+k',
       selection,
       setSelection,
@@ -327,6 +377,7 @@ export function MedaShellProvider(props: MedaShellProviderProps) {
       props.mobileBottomNav,
       mobileDrawer,
       commandPalette,
+      panelViews,
       props.commandPaletteHotkey,
       selection,
     ]

--- a/src/shell/types.ts
+++ b/src/shell/types.ts
@@ -18,7 +18,8 @@ export interface ContextModule {
   id: string;
   label: string;
   description?: string;
-  items: ContextItem[];
+  items?: ContextItem[];
+  render?: (ctx: ShellRenderContext) => ReactNode;
 }
 
 export interface ContextItem {


### PR DESCRIPTION
## Summary

Adds route-owned shell composition APIs for Meda 1.3.0:

- add `ContextModule.render` and optional `ContextModule.items`
- render dynamic context module content on desktop and mobile
- add `PanelViewsProvider` for route-owned right-panel view registration
- merge static and registered panel views with route views overriding duplicate ids
- document the pattern in Storybook and add a changeset

## Validation

- `pnpm check:stories`
- `pnpm test -- context-rail right-panel app-shell-workspace`
- `pnpm typecheck`
- `pnpm build`

Targets the Meda 1.3.0 umbrella branch.