### PR TITLE
Sync 1.3.0 release back into dev

### DIFF
--- a/.changeset/meda-shell-adoption-core.md
+++ b/.changeset/meda-shell-adoption-core.md
@@ -1,5 +1,0 @@
----
-"@medalsocial/meda": minor
----
-
-Document shell adoption helpers with a Storybook workspace example covering `iconRail.renderLink` pass-through, the `panel.open`, `panel.close`, `panel.toggle`, and `contextRail.toggle` helpers, and `CommandDefinition.hotkey` as a display-only alias where `shortcut` wins when both are supplied.

--- a/.changeset/meda-shell-dynamic-composition.md
+++ b/.changeset/meda-shell-dynamic-composition.md
@@ -1,5 +1,0 @@
----
-'@medalsocial/meda': minor
----
-
-Add dynamic shell composition APIs: context modules can render custom content in desktop and mobile rails, and route content can register right-panel views with PanelViewsProvider.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @medalsocial/meda
 
+## 1.3.0
+
+### Minor Changes
+
+- [#68](https://github.com/Medal-Social/meda/pull/68) [`983e648`](https://github.com/Medal-Social/meda/commit/983e6481875787122e65b0087fd05a014018e33c) Thanks [@alioftech](https://github.com/alioftech)! - Document shell adoption helpers with a Storybook workspace example covering `iconRail.renderLink` pass-through, the `panel.open`, `panel.close`, `panel.toggle`, and `contextRail.toggle` helpers, and `CommandDefinition.hotkey` as a display-only alias where `shortcut` wins when both are supplied.
+
+- [#69](https://github.com/Medal-Social/meda/pull/69) [`5a496a2`](https://github.com/Medal-Social/meda/commit/5a496a29b2f87f4fd6fca6daa77fefe71a4e6e8f) Thanks [@alioftech](https://github.com/alioftech)! - Add dynamic shell composition APIs: context modules can render custom content in desktop and mobile rails, and route content can register right-panel views with PanelViewsProvider.
+
 ## 1.2.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@medalsocial/meda",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Shared Meda UI shell and runtime package.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary
- Sync the published `@medalsocial/meda@1.3.0` release commit from `prod` back into `dev`.
- Bring `package.json`, `CHANGELOG.md`, and consumed changeset cleanup into the development branch.
- Keep future feature branches based on the released 1.3.0 state.

## Release context
- `@medalsocial/meda@1.3.0` has been published to npm and is tagged as `latest`.
- Release PR #71 merged into `prod` and created the `@medalsocial/meda@1.3.0` GitHub release/tag.
- This PR is a post-release branch sync only; it should not publish another package version.

## Test plan
- Release PR #71 checks passed before merge.
- Prod release workflow completed successfully and published `@medalsocial/meda@1.3.0`.
- This PR's CI, CodeQL, size-limit, Storybook build, and request checks are green.
