### PR TITLE
Auth adoption controls

### DIFF
--- a/.changeset/meda-auth-adoption-controls.md
+++ b/.changeset/meda-auth-adoption-controls.md
@@ -1,0 +1,5 @@
+---
+'@medalsocial/meda': minor
+---
+
+Adds auth adoption controls, `AppShell` auth branding shorthand, and an optional better-auth adapter subpath.

--- a/.changeset/meda-package-recipes.md
+++ b/.changeset/meda-package-recipes.md
@@ -1,0 +1,5 @@
+---
+"@medalsocial/meda": minor
+---
+
+Add shell primitive and Next recipe package subpaths, plus registry metadata for copyable AppShell adoption recipes.

--- a/.changeset/meda-render-prop-boundaries.md
+++ b/.changeset/meda-render-prop-boundaries.md
@@ -1,0 +1,5 @@
+---
+"@medalsocial/meda": minor
+---
+
+Add render-boundary adapter props for auth provider buttons, shell rail links, and right panel tabs so consumers can integrate routers, analytics, and wrapper components while preserving Meda ARIA, state, and event props.

--- a/.changeset/meda-theme-bridge-contracts.md
+++ b/.changeset/meda-theme-bridge-contracts.md
@@ -1,0 +1,5 @@
+---
+"@medalsocial/meda": minor
+---
+
+Add a public theme bridge helper for app-scoped Meda token CSS and strengthen Next recipe accessibility/composition contracts.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # @medalsocial/meda
 
-Shared UI shell and runtime primitives — the navigation chrome, panels, tab bars, command palette, and workbench layout that power Medal's apps. Published as Apache-2.0.
+Shared UI shell and runtime primitives — the navigation chrome, panels, auth controls, recipes, theme bridges, command palette, and workbench layout that power Medal's apps. Published as Apache-2.0.
 
 ![npm](https://img.shields.io/npm/v/@medalsocial/meda)
 
 ## Install
 
 ```bash
-pnpm add @medalsocial/meda
+pnpm add @medalsocial/meda lucide-react
 ```
 
-Peer deps: `react >= 19`, `react-dom >= 19`.
+Peer deps: `react >= 19`, `react-dom >= 19`, and `lucide-react`.
 
 ## Tailwind CSS v4 setup
 
@@ -22,36 +22,81 @@ Meda ships a `styles.css` with its design tokens. Import it once in your entry s
 
 ## Usage
 
-`ShellStateProvider` stores panel/selection state in URL search params and is router-agnostic. You provide a `ShellSearchParamsAdapter` so it can read and update them however your router prefers. A minimal, in-memory adapter:
+Use `AppShell` for the styled shell surface:
 
 ```tsx
-import { useState } from 'react';
-import { ShellStateProvider, ShellFrame } from '@medalsocial/meda';
+import { AppShell, MedaShellProvider } from '@medalsocial/meda/shell';
+import { Inbox } from 'lucide-react';
 
 export function App() {
-  const [searchParams, setSearchParams] = useState(() => new URLSearchParams());
+  const workspace = { id: 'workspace', name: 'Workspace' };
+  const apps = [{ id: 'inbox', label: 'Inbox', icon: Inbox }];
 
   return (
-    <ShellStateProvider
-      adapter={{
-        searchParams,
-        setSearchParams: (updater) => setSearchParams((current) => updater(current)),
-      }}
-    >
-      <ShellFrame>{/* your app */}</ShellFrame>
-    </ShellStateProvider>
+    <MedaShellProvider workspace={workspace} apps={apps}>
+      <AppShell
+        variant="workspace"
+        iconRail={{
+          mainItems: [{ id: 'inbox', label: 'Inbox', icon: Inbox, to: '/inbox' }],
+        }}
+      >
+        {/* your app */}
+      </AppShell>
+    </MedaShellProvider>
   );
 }
 ```
 
-For a real app, wire the adapter to your router (e.g. TanStack Router's `useSearch`/`useNavigate`, React Router's `useSearchParams`) so URL changes persist state.
+For framework routing, pass a render callback and forward Meda props:
+
+```tsx
+import Link from 'next/link';
+
+<AppShell
+  variant="workspace"
+  iconRail={{
+    mainItems,
+    renderLink: ({ item, linkProps }) => <Link {...linkProps} href={item.to} prefetch />,
+  }}
+>
+  {children}
+</AppShell>;
+```
+
+For app-scoped brand tokens:
+
+```ts
+import { createMedaThemeCss, defineMedaTheme } from '@medalsocial/meda/theme';
+
+const css = createMedaThemeCss(
+  defineMedaTheme({
+    appId: 'auto',
+    colors: {
+      primary: 'var(--hb-brand-500)',
+      background: 'var(--hb-base-50)',
+    },
+    dark: {
+      colors: {
+        background: 'var(--hb-base-900)',
+      },
+    },
+  })
+);
+```
+
+Lower-level `ShellStateProvider` and layout parts remain available from `@medalsocial/meda/shell/primitives` for apps that need to own more composition.
 
 See the [demo app](./demo) for a live playground.
 
 ## Exports
 
 - `@medalsocial/meda` — curated public API (components + helpers)
-- `@medalsocial/meda/shell` — shell-only subpath
+- `@medalsocial/meda/shell` — styled shell components and hooks
+- `@medalsocial/meda/shell/primitives` — lower-level shell state and layout primitives
+- `@medalsocial/meda/auth` — provider-neutral auth controls
+- `@medalsocial/meda/auth/better-auth` — optional better-auth adapter
+- `@medalsocial/meda/recipes/next` — copyable Next.js adoption recipe metadata
+- `@medalsocial/meda/theme` — app-scoped token bridge helpers
 - `@medalsocial/meda/marketing` — marketing sections and campaign blocks
 - `@medalsocial/meda/styles.css` — design tokens + base styles
 
@@ -64,6 +109,7 @@ Prefer to copy source into your project instead of installing? The shadcn-compat
 npx shadcn add https://meda.medalsocial.com/r/meda-shell.json
 npx shadcn add https://meda.medalsocial.com/r/meda-shell-state.json
 npx shadcn add https://meda.medalsocial.com/r/meda-workbench-layout.json
+npx shadcn add https://meda.medalsocial.com/r/meda-next-app-shell.json
 ```
 
 The registry index is at `https://meda.medalsocial.com/registry.json`. Source JSON files live under [`./registry`](./registry) in this repo and are deployed as static assets via Cloudflare Workers — see `wrangler.toml` and `.github/workflows/deploy-worker.yml`.

--- a/dist/auth/auth-message.d.ts
+++ b/dist/auth/auth-message.d.ts
@@ -1,0 +1,10 @@
+import type { HTMLAttributes, ReactNode } from 'react';
+export interface AuthMessageProps extends HTMLAttributes<HTMLDivElement> {
+    children?: ReactNode;
+}
+export declare function AuthError({ children, className, ...props }: AuthMessageProps): import("react/jsx-runtime").JSX.Element | null;
+export declare function AuthNotice({ children, className, ...props }: AuthMessageProps): import("react/jsx-runtime").JSX.Element | null;
+export interface AuthOneTapSlotProps extends HTMLAttributes<HTMLDivElement> {
+    children?: ReactNode;
+}
+export declare function AuthOneTapSlot({ children, className, ...props }: AuthOneTapSlotProps): import("react/jsx-runtime").JSX.Element;

--- a/dist/auth/auth-message.js
+++ b/dist/auth/auth-message.js
@@ -1,0 +1,18 @@
+'use client';
+import { jsx as _jsx } from "react/jsx-runtime";
+import { cn } from '../lib/utils.js';
+export function AuthError({ children, className, ...props }) {
+    if (!children) {
+        return null;
+    }
+    return (_jsx("div", { role: "alert", className: cn('rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive', className), ...props, children: children }));
+}
+export function AuthNotice({ children, className, ...props }) {
+    if (!children) {
+        return null;
+    }
+    return (_jsx("div", { className: cn('rounded-md border border-border bg-muted/60 px-3 py-2 text-sm text-muted-foreground', className), ...props, children: children }));
+}
+export function AuthOneTapSlot({ children, className, ...props }) {
+    return (_jsx("div", { "data-meda-auth-one-tap-slot": "", className: cn('contents', className), ...props, children: children }));
+}

--- a/dist/auth/auth-provider-button.d.ts
+++ b/dist/auth/auth-provider-button.d.ts
@@ -1,4 +1,5 @@
 import type { ButtonHTMLAttributes, ReactNode } from 'react';
+import { type RenderElement } from '../lib/render-element.js';
 export type AuthProvider = 'google' | (string & {});
 export interface AuthProviderButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {
     provider?: AuthProvider;
@@ -8,5 +9,6 @@ export interface AuthProviderButtonProps extends Omit<ButtonHTMLAttributes<HTMLB
     loadingLabel?: ReactNode;
     lastUsed?: boolean;
     lastUsedLabel?: ReactNode;
+    render?: RenderElement<ButtonHTMLAttributes<HTMLButtonElement>>;
 }
-export declare function AuthProviderButton({ provider, label, icon, loading, loadingLabel, lastUsed, lastUsedLabel, disabled, className, type, ...props }: AuthProviderButtonProps): import("react/jsx-runtime").JSX.Element;
+export declare function AuthProviderButton({ provider, label, icon, loading, loadingLabel, lastUsed, lastUsedLabel, render, disabled, className, type, ...props }: AuthProviderButtonProps): string | number | bigint | boolean | Iterable<ReactNode> | Promise<string | number | bigint | boolean | import("react").ReactPortal | import("react").ReactElement<unknown, string | import("react").JSXElementConstructor<any>> | Iterable<ReactNode> | null | undefined> | import("react/jsx-runtime").JSX.Element | null | undefined;

--- a/dist/auth/auth-provider-button.d.ts
+++ b/dist/auth/auth-provider-button.d.ts
@@ -1,0 +1,12 @@
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+export type AuthProvider = 'google' | (string & {});
+export interface AuthProviderButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {
+    provider?: AuthProvider;
+    label: ReactNode;
+    icon?: ReactNode;
+    loading?: boolean;
+    loadingLabel?: ReactNode;
+    lastUsed?: boolean;
+    lastUsedLabel?: ReactNode;
+}
+export declare function AuthProviderButton({ provider, label, icon, loading, loadingLabel, lastUsed, lastUsedLabel, disabled, className, type, ...props }: AuthProviderButtonProps): import("react/jsx-runtime").JSX.Element;

--- a/dist/auth/auth-provider-button.js
+++ b/dist/auth/auth-provider-button.js
@@ -1,10 +1,25 @@
 'use client';
-import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
+import { jsx as _jsx, Fragment as _Fragment, jsxs as _jsxs } from "react/jsx-runtime";
+import { renderElement } from '../lib/render-element.js';
 import { cn } from '../lib/utils.js';
-export function AuthProviderButton({ provider, label, icon, loading = false, loadingLabel = 'Loading...', lastUsed = false, lastUsedLabel = 'Last used', disabled, className, type = 'button', ...props }) {
+export function AuthProviderButton({ provider, label, icon, loading = false, loadingLabel = 'Loading...', lastUsed = false, lastUsedLabel = 'Last used', render, disabled, className, type = 'button', ...props }) {
     const resolvedIcon = icon ?? (provider === 'google' ? _jsx(GoogleIcon, {}) : null);
     const isDisabled = disabled || loading;
-    return (_jsxs("button", { type: type, disabled: isDisabled, "aria-busy": loading || undefined, "data-provider": provider, "data-last-used": lastUsed || undefined, className: cn('relative inline-flex min-h-11 w-full items-center justify-center gap-3 rounded-md border border-border bg-background px-4 py-2.5 text-sm font-medium text-foreground shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-60', className), ...props, children: [resolvedIcon && (_jsx("span", { className: "flex size-5 shrink-0 items-center justify-center", "aria-hidden": "true", children: resolvedIcon })), _jsx("span", { className: "min-w-0 truncate", children: loading ? loadingLabel : label }), lastUsed && !loading && (_jsx("span", { "aria-hidden": "true", className: "ml-auto shrink-0 rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground", children: lastUsedLabel }))] }));
+    const children = (_jsxs(_Fragment, { children: [resolvedIcon && (_jsx("span", { className: "flex size-5 shrink-0 items-center justify-center", "aria-hidden": "true", children: resolvedIcon })), _jsx("span", { className: "min-w-0 truncate", children: loading ? loadingLabel : label }), lastUsed && !loading && (_jsx("span", { "aria-hidden": "true", className: "ml-auto shrink-0 rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground", children: lastUsedLabel }))] }));
+    const buttonProps = {
+        type,
+        disabled: isDisabled,
+        'aria-busy': loading || undefined,
+        'data-provider': provider,
+        'data-last-used': lastUsed || undefined,
+        className: cn('relative inline-flex min-h-11 w-full items-center justify-center gap-3 rounded-md border border-border bg-background px-4 py-2.5 text-sm font-medium text-foreground shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-60', className),
+        ...props,
+        children,
+    };
+    if (render) {
+        return renderElement(render, buttonProps);
+    }
+    return _jsx("button", { ...buttonProps });
 }
 function GoogleIcon() {
     return (_jsxs("svg", { viewBox: "0 0 24 24", className: "size-5", "aria-hidden": "true", children: [_jsx("path", { fill: "#4285F4", d: "M21.6 12.23c0-.82-.07-1.42-.22-2.05H12v3.72h5.51c-.11.92-.71 2.31-2.04 3.24l-.02.12 2.96 2.29.2.02c1.86-1.72 2.99-4.25 2.99-7.34z" }), _jsx("path", { fill: "#34A853", d: "M12 22c2.66 0 4.89-.88 6.52-2.39l-3.11-2.42c-.83.58-1.95.99-3.41.99a5.93 5.93 0 0 1-5.6-4.1l-.12.01-3.08 2.39-.04.11A9.85 9.85 0 0 0 12 22z" }), _jsx("path", { fill: "#FBBC05", d: "M6.4 14.08A6.17 6.17 0 0 1 6.07 12c0-.72.12-1.42.32-2.08l-.01-.13-3.12-2.42-.1.05A9.93 9.93 0 0 0 2.1 12c0 1.64.39 3.19 1.07 4.57l3.23-2.49z" }), _jsx("path", { fill: "#EA4335", d: "M12 5.82c1.85 0 3.1.8 3.81 1.47l2.78-2.72C16.88 2.98 14.66 2 12 2a9.85 9.85 0 0 0-8.84 5.42l3.22 2.5A5.96 5.96 0 0 1 12 5.82z" })] }));

--- a/dist/auth/auth-provider-button.js
+++ b/dist/auth/auth-provider-button.js
@@ -1,0 +1,11 @@
+'use client';
+import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
+import { cn } from '../lib/utils.js';
+export function AuthProviderButton({ provider, label, icon, loading = false, loadingLabel = 'Loading...', lastUsed = false, lastUsedLabel = 'Last used', disabled, className, type = 'button', ...props }) {
+    const resolvedIcon = icon ?? (provider === 'google' ? _jsx(GoogleIcon, {}) : null);
+    const isDisabled = disabled || loading;
+    return (_jsxs("button", { type: type, disabled: isDisabled, "aria-busy": loading || undefined, "data-provider": provider, "data-last-used": lastUsed || undefined, className: cn('relative inline-flex min-h-11 w-full items-center justify-center gap-3 rounded-md border border-border bg-background px-4 py-2.5 text-sm font-medium text-foreground shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-60', className), ...props, children: [resolvedIcon && (_jsx("span", { className: "flex size-5 shrink-0 items-center justify-center", "aria-hidden": "true", children: resolvedIcon })), _jsx("span", { className: "min-w-0 truncate", children: loading ? loadingLabel : label }), lastUsed && !loading && (_jsx("span", { "aria-hidden": "true", className: "ml-auto shrink-0 rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground", children: lastUsedLabel }))] }));
+}
+function GoogleIcon() {
+    return (_jsxs("svg", { viewBox: "0 0 24 24", className: "size-5", "aria-hidden": "true", children: [_jsx("path", { fill: "#4285F4", d: "M21.6 12.23c0-.82-.07-1.42-.22-2.05H12v3.72h5.51c-.11.92-.71 2.31-2.04 3.24l-.02.12 2.96 2.29.2.02c1.86-1.72 2.99-4.25 2.99-7.34z" }), _jsx("path", { fill: "#34A853", d: "M12 22c2.66 0 4.89-.88 6.52-2.39l-3.11-2.42c-.83.58-1.95.99-3.41.99a5.93 5.93 0 0 1-5.6-4.1l-.12.01-3.08 2.39-.04.11A9.85 9.85 0 0 0 12 22z" }), _jsx("path", { fill: "#FBBC05", d: "M6.4 14.08A6.17 6.17 0 0 1 6.07 12c0-.72.12-1.42.32-2.08l-.01-.13-3.12-2.42-.1.05A9.93 9.93 0 0 0 2.1 12c0 1.64.39 3.19 1.07 4.57l3.23-2.49z" }), _jsx("path", { fill: "#EA4335", d: "M12 5.82c1.85 0 3.1.8 3.81 1.47l2.78-2.72C16.88 2.98 14.66 2 12 2a9.85 9.85 0 0 0-8.84 5.42l3.22 2.5A5.96 5.96 0 0 1 12 5.82z" })] }));
+}

--- a/dist/auth/auth-provider-list.d.ts
+++ b/dist/auth/auth-provider-list.d.ts
@@ -1,0 +1,6 @@
+import { type HTMLAttributes, type ReactNode } from 'react';
+export interface AuthProviderListProps extends HTMLAttributes<HTMLUListElement> {
+    children: ReactNode;
+    label?: string;
+}
+export declare function AuthProviderList({ children, className, label, ...props }: AuthProviderListProps): import("react/jsx-runtime").JSX.Element;

--- a/dist/auth/auth-provider-list.js
+++ b/dist/auth/auth-provider-list.js
@@ -1,0 +1,7 @@
+'use client';
+import { jsx as _jsx } from "react/jsx-runtime";
+import { Children, isValidElement } from 'react';
+import { cn } from '../lib/utils.js';
+export function AuthProviderList({ children, className, label = 'Authentication providers', ...props }) {
+    return (_jsx("ul", { "aria-label": label, className: cn('flex w-full flex-col gap-3', className), ...props, children: Children.toArray(children).map((child, index) => (_jsx("li", { className: "contents", children: child }, isValidElement(child) && child.key != null ? child.key : index))) }));
+}

--- a/dist/auth/better-auth.d.ts
+++ b/dist/auth/better-auth.d.ts
@@ -1,0 +1,40 @@
+import { type AuthProviderButtonProps } from './auth-provider-button.js';
+export interface BetterAuthSocialArgs {
+    provider: string;
+    callbackURL?: string;
+    errorCallbackURL?: string;
+}
+export interface BetterAuthOneTapArgs {
+    callbackURL?: string;
+}
+export interface BetterAuthClientLike {
+    signIn?: {
+        social?: (args: BetterAuthSocialArgs) => Promise<unknown> | unknown;
+    };
+    oneTap?: (args: BetterAuthOneTapArgs) => Promise<unknown> | unknown;
+    getLastUsedLoginMethod?: () => Promise<string | null | undefined> | string | null | undefined;
+}
+export interface BetterAuthProviderButtonProps extends Omit<AuthProviderButtonProps, 'onClick' | 'provider'> {
+    authClient: BetterAuthClientLike;
+    provider?: string;
+    callbackURL?: string;
+    errorCallbackURL?: string;
+    onPendingChange?: (pending: boolean) => void;
+    onError?: (error: unknown) => void;
+    onSuccess?: (result: unknown) => void;
+}
+export declare function BetterAuthProviderButton({ authClient, provider, callbackURL, errorCallbackURL, onPendingChange, onError, onSuccess, loading, ...props }: BetterAuthProviderButtonProps): import("react/jsx-runtime").JSX.Element;
+export declare function useBetterAuthLastLoginMethod(authClient: BetterAuthClientLike): string | null;
+export interface BetterAuthOneTapProps {
+    authClient: BetterAuthClientLike;
+    enabled?: boolean;
+    callbackURL?: string;
+    onError?: (error: unknown) => void;
+    onSuccess?: (result: unknown) => void;
+}
+export declare function BetterAuthOneTap({ authClient, enabled, callbackURL, onError, onSuccess, }: BetterAuthOneTapProps): null;
+export declare function createBetterAuthAdapter(authClient: BetterAuthClientLike): {
+    BetterAuthProviderButton: (props: Omit<BetterAuthProviderButtonProps, "authClient">) => import("react/jsx-runtime").JSX.Element;
+    BetterAuthOneTap: (props: Omit<BetterAuthOneTapProps, "authClient">) => import("react/jsx-runtime").JSX.Element;
+    useBetterAuthLastLoginMethod: () => string | null;
+};

--- a/dist/auth/better-auth.js
+++ b/dist/auth/better-auth.js
@@ -1,0 +1,92 @@
+'use client';
+import { jsx as _jsx } from "react/jsx-runtime";
+import { useEffect, useRef, useState } from 'react';
+import { AuthProviderButton } from './auth-provider-button.js';
+export function BetterAuthProviderButton({ authClient, provider = 'google', callbackURL, errorCallbackURL, onPendingChange, onError, onSuccess, loading, ...props }) {
+    const [internalPending, setInternalPending] = useState(false);
+    const pending = loading ?? internalPending;
+    return (_jsx(AuthProviderButton, { provider: provider, loading: pending, onClick: async () => {
+            const social = authClient.signIn?.social;
+            if (!social) {
+                onError?.(new Error('better-auth social sign-in is unavailable.'));
+                return;
+            }
+            setInternalPending(true);
+            onPendingChange?.(true);
+            try {
+                const result = await social({ provider, callbackURL, errorCallbackURL });
+                onSuccess?.(result);
+            }
+            catch (error) {
+                onError?.(error);
+            }
+            finally {
+                setInternalPending(false);
+                onPendingChange?.(false);
+            }
+        }, ...props }));
+}
+export function useBetterAuthLastLoginMethod(authClient) {
+    const [method, setMethod] = useState(null);
+    useEffect(() => {
+        let active = true;
+        async function loadLastMethod() {
+            try {
+                const getter = authClient.getLastUsedLoginMethod;
+                const nextMethod = getter ? await getter() : null;
+                if (active) {
+                    setMethod(nextMethod ?? null);
+                }
+            }
+            catch {
+                if (active) {
+                    setMethod(null);
+                }
+            }
+        }
+        void loadLastMethod();
+        return () => {
+            active = false;
+        };
+    }, [authClient]);
+    return method;
+}
+export function BetterAuthOneTap({ authClient, enabled = true, callbackURL, onError, onSuccess, }) {
+    const onErrorRef = useRef(onError);
+    const onSuccessRef = useRef(onSuccess);
+    useEffect(() => {
+        onErrorRef.current = onError;
+        onSuccessRef.current = onSuccess;
+    }, [onError, onSuccess]);
+    useEffect(() => {
+        if (!enabled || !authClient.oneTap) {
+            return;
+        }
+        let active = true;
+        async function mountOneTap() {
+            try {
+                const result = await authClient.oneTap?.({ callbackURL });
+                if (active) {
+                    onSuccessRef.current?.(result);
+                }
+            }
+            catch (error) {
+                if (active) {
+                    onErrorRef.current?.(error);
+                }
+            }
+        }
+        void mountOneTap();
+        return () => {
+            active = false;
+        };
+    }, [authClient, callbackURL, enabled]);
+    return null;
+}
+export function createBetterAuthAdapter(authClient) {
+    return {
+        BetterAuthProviderButton: (props) => (_jsx(BetterAuthProviderButton, { authClient: authClient, ...props })),
+        BetterAuthOneTap: (props) => (_jsx(BetterAuthOneTap, { authClient: authClient, ...props })),
+        useBetterAuthLastLoginMethod: () => useBetterAuthLastLoginMethod(authClient),
+    };
+}

--- a/dist/auth/better-auth.js
+++ b/dist/auth/better-auth.js
@@ -5,7 +5,7 @@ import { AuthProviderButton } from './auth-provider-button.js';
 export function BetterAuthProviderButton({ authClient, provider = 'google', callbackURL, errorCallbackURL, onPendingChange, onError, onSuccess, loading, ...props }) {
     const [internalPending, setInternalPending] = useState(false);
     const pending = loading ?? internalPending;
-    return (_jsx(AuthProviderButton, { provider: provider, loading: pending, onClick: async () => {
+    return (_jsx(AuthProviderButton, { ...props, provider: provider, loading: pending, onClick: async () => {
             const social = authClient.signIn?.social;
             if (!social) {
                 onError?.(new Error('better-auth social sign-in is unavailable.'));
@@ -24,7 +24,7 @@ export function BetterAuthProviderButton({ authClient, provider = 'google', call
                 setInternalPending(false);
                 onPendingChange?.(false);
             }
-        }, ...props }));
+        } }));
 }
 export function useBetterAuthLastLoginMethod(authClient) {
     const [method, setMethod] = useState(null);

--- a/dist/auth/better-auth.js
+++ b/dist/auth/better-auth.js
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import { AuthProviderButton } from './auth-provider-button.js';
 export function BetterAuthProviderButton({ authClient, provider = 'google', callbackURL, errorCallbackURL, onPendingChange, onError, onSuccess, loading, ...props }) {
     const [internalPending, setInternalPending] = useState(false);
-    const pending = loading ?? internalPending;
+    const pending = Boolean(loading || internalPending);
     return (_jsx(AuthProviderButton, { ...props, provider: provider, loading: pending, onClick: async () => {
             const social = authClient.signIn?.social;
             if (!social) {

--- a/dist/auth/index.d.ts
+++ b/dist/auth/index.d.ts
@@ -1,0 +1,6 @@
+export type { AuthMessageProps, AuthOneTapSlotProps } from './auth-message.js';
+export { AuthError, AuthNotice, AuthOneTapSlot } from './auth-message.js';
+export type { AuthProvider, AuthProviderButtonProps } from './auth-provider-button.js';
+export { AuthProviderButton } from './auth-provider-button.js';
+export type { AuthProviderListProps } from './auth-provider-list.js';
+export { AuthProviderList } from './auth-provider-list.js';

--- a/dist/auth/index.js
+++ b/dist/auth/index.js
@@ -1,0 +1,3 @@
+export { AuthError, AuthNotice, AuthOneTapSlot } from './auth-message.js';
+export { AuthProviderButton } from './auth-provider-button.js';
+export { AuthProviderList } from './auth-provider-list.js';

--- a/dist/auth/public.d.ts
+++ b/dist/auth/public.d.ts
@@ -1,0 +1,6 @@
+export type { AuthMessageProps, AuthOneTapSlotProps } from './auth-message.js';
+export { AuthError, AuthNotice, AuthOneTapSlot } from './auth-message.js';
+export type { AuthProvider, AuthProviderButtonProps } from './auth-provider-button.js';
+export { AuthProviderButton } from './auth-provider-button.js';
+export type { AuthProviderListProps } from './auth-provider-list.js';
+export { AuthProviderList } from './auth-provider-list.js';

--- a/dist/auth/public.js
+++ b/dist/auth/public.js
@@ -1,0 +1,3 @@
+export { AuthError, AuthNotice, AuthOneTapSlot } from './auth-message.js';
+export { AuthProviderButton } from './auth-provider-button.js';
+export { AuthProviderList } from './auth-provider-list.js';

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -4,4 +4,5 @@ export * from './chat/public.js';
 export * from './marketing/public.js';
 export * from './panel/public.js';
 export * from './shell/index.js';
+export * from './theme/index.js';
 export * from './timeline/public.js';

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,3 +1,4 @@
+export * from './auth/public.js';
 export * from './brand/public.js';
 export * from './chat/public.js';
 export * from './marketing/public.js';

--- a/dist/index.js
+++ b/dist/index.js
@@ -4,4 +4,5 @@ export * from './chat/public.js';
 export * from './marketing/public.js';
 export * from './panel/public.js';
 export * from './shell/index.js'; // v2 surface
+export * from './theme/index.js';
 export * from './timeline/public.js';

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,3 +1,4 @@
+export * from './auth/public.js';
 export * from './brand/public.js';
 export * from './chat/public.js';
 export * from './marketing/public.js';

--- a/dist/lib/render-element.d.ts
+++ b/dist/lib/render-element.d.ts
@@ -1,0 +1,9 @@
+import { type ReactElement, type ReactNode } from 'react';
+export type RenderElement<TProps extends {
+    className?: string;
+    children?: ReactNode;
+}> = ReactElement<Partial<TProps>>;
+export declare function renderElement<TProps extends {
+    className?: string;
+    children?: ReactNode;
+}>(render: RenderElement<TProps>, props: TProps): ReactNode;

--- a/dist/lib/render-element.js
+++ b/dist/lib/render-element.js
@@ -1,0 +1,27 @@
+import { cloneElement, isValidElement, } from 'react';
+import { cn } from './utils.js';
+function composeEventHandlers(consumerHandler, medaHandler) {
+    if (!consumerHandler)
+        return medaHandler;
+    if (!medaHandler)
+        return consumerHandler;
+    return (event) => {
+        consumerHandler(event);
+        if (!event.defaultPrevented) {
+            medaHandler(event);
+        }
+    };
+}
+export function renderElement(render, props) {
+    if (!isValidElement(render))
+        return null;
+    const renderProps = render.props;
+    const medaProps = props;
+    return cloneElement(render, {
+        ...renderProps,
+        ...medaProps,
+        className: cn(renderProps.className, medaProps.className),
+        onClick: composeEventHandlers(renderProps.onClick, medaProps.onClick),
+        onKeyDown: composeEventHandlers(renderProps.onKeyDown, medaProps.onKeyDown),
+    });
+}

--- a/dist/recipes/next.d.ts
+++ b/dist/recipes/next.d.ts
@@ -13,6 +13,7 @@ export interface MedaRecipe {
     cssVars: string[];
     files: MedaRecipeFile[];
     accessibility: string[];
+    composition: string[];
 }
 export declare const nextAppShellRecipe: {
     name: string;
@@ -28,6 +29,7 @@ export declare const nextAppShellRecipe: {
         content: string;
     }[];
     accessibility: string[];
+    composition: string[];
 };
 export declare const nextRecipes: {
     name: string;
@@ -43,4 +45,5 @@ export declare const nextRecipes: {
         content: string;
     }[];
     accessibility: string[];
+    composition: string[];
 }[];

--- a/dist/recipes/next.d.ts
+++ b/dist/recipes/next.d.ts
@@ -1,0 +1,46 @@
+export interface MedaRecipeFile {
+    path: string;
+    target: string;
+    type: 'registry:block' | 'registry:component' | 'registry:hook' | 'registry:lib';
+    content: string;
+}
+export interface MedaRecipe {
+    name: string;
+    title: string;
+    description: string;
+    dependencies: string[];
+    peerDependencies: string[];
+    cssVars: string[];
+    files: MedaRecipeFile[];
+    accessibility: string[];
+}
+export declare const nextAppShellRecipe: {
+    name: string;
+    title: string;
+    description: string;
+    dependencies: string[];
+    peerDependencies: string[];
+    cssVars: string[];
+    files: {
+        path: string;
+        target: string;
+        type: "registry:block";
+        content: string;
+    }[];
+    accessibility: string[];
+};
+export declare const nextRecipes: {
+    name: string;
+    title: string;
+    description: string;
+    dependencies: string[];
+    peerDependencies: string[];
+    cssVars: string[];
+    files: {
+        path: string;
+        target: string;
+        type: "registry:block";
+        content: string;
+    }[];
+    accessibility: string[];
+}[];

--- a/dist/recipes/next.js
+++ b/dist/recipes/next.js
@@ -118,5 +118,11 @@ export function MedaNextAuthShell({
         'Route-owned panel views should expose headings inside their rendered panel content.',
         'Reduced-motion behavior remains delegated to Meda shell motion tokens.',
     ],
+    composition: [
+        'MedaShellProvider owns workspace and app context for the copied shell adapter.',
+        'AppShell receives route-owned rightPanel views on first render to avoid delayed panel UI.',
+        'PanelViewsProvider wraps children with the same panelViews and defaultPanelView for nested route registrations.',
+        'renderLink composes Next Link by forwarding Meda linkProps before setting framework-specific props.',
+    ],
 };
 export const nextRecipes = [nextAppShellRecipe];

--- a/dist/recipes/next.js
+++ b/dist/recipes/next.js
@@ -1,0 +1,122 @@
+export const nextAppShellRecipe = {
+    name: 'meda-next-app-shell',
+    title: 'Meda Next AppShell',
+    description: 'Copyable Next.js App Router shell adapter with next/link routing, route-owned panel views, and auth controls.',
+    dependencies: ['@medalsocial/meda', 'lucide-react'],
+    peerDependencies: ['next', 'react', 'react-dom'],
+    cssVars: ['@medalsocial/meda/styles.css'],
+    files: [
+        {
+            path: 'registry/meda/meda-next-app-shell/meda-next-app-shell.tsx',
+            target: 'components/meda/meda-next-app-shell.tsx',
+            type: 'registry:block',
+            content: `\
+'use client'
+
+import Link from 'next/link'
+import type { ComponentProps, ReactNode } from 'react'
+import {
+  AppShell,
+  AuthError,
+  AuthNotice,
+  AuthOneTapSlot,
+  AuthProviderButton,
+  AuthProviderList,
+  MedaShellProvider,
+  PanelViewsProvider,
+  type AppDefinition,
+  type IconRailItem,
+  type PanelView,
+  type WorkspaceDefinition,
+} from '@medalsocial/meda/shell'
+
+export function MedaNextWorkspaceShell({
+  workspace,
+  apps,
+  iconItems,
+  activeIconId,
+  panelViews = [],
+  defaultPanelView,
+  children,
+}: {
+  workspace: WorkspaceDefinition
+  apps: AppDefinition[]
+  iconItems: IconRailItem[]
+  activeIconId?: string
+  panelViews?: PanelView[]
+  defaultPanelView?: string
+  children: ReactNode
+}) {
+  return (
+    <MedaShellProvider workspace={workspace} apps={apps}>
+      <AppShell
+        variant="workspace"
+        iconRail={{
+          mainItems: iconItems,
+          activeId: activeIconId,
+          renderLink: ({ item, linkProps }) => (
+            <Link {...linkProps} href={item.to} prefetch />
+          ),
+        }}
+        rightPanel={{ panelViews, defaultView: defaultPanelView }}
+      >
+        <PanelViewsProvider views={panelViews} defaultView={defaultPanelView}>
+          {children}
+        </PanelViewsProvider>
+      </AppShell>
+    </MedaShellProvider>
+  )
+}
+
+export function MedaNextAuthShell({
+  brandName,
+  brandMark,
+  appName,
+  tagline,
+  preview,
+  error,
+  notice,
+  onGoogleSignIn,
+}: {
+  brandName: ReactNode
+  brandMark?: ReactNode
+  appName?: ReactNode
+  tagline?: ReactNode
+  preview?: ReactNode
+  error?: ReactNode
+  notice?: ReactNode
+  onGoogleSignIn: ComponentProps<typeof AuthProviderButton>['onClick']
+}) {
+  return (
+    <MedaShellProvider workspace={{ id: 'auth', name: 'Auth', icon: brandMark }} apps={[]}>
+      <AppShell
+        variant="auth"
+        branding={{ brandName, brandMark, appName, tagline }}
+        preview={preview}
+      >
+        <AuthProviderList>
+          <AuthProviderButton
+            provider="google"
+            label="Continue with Google"
+            onClick={onGoogleSignIn}
+          />
+        </AuthProviderList>
+        <AuthNotice>{notice}</AuthNotice>
+        <AuthError>{error}</AuthError>
+        <AuthOneTapSlot />
+      </AppShell>
+    </MedaShellProvider>
+  )
+}
+`,
+        },
+    ],
+    accessibility: [
+        'Every drawer and panel keeps its accessible name from AppShell and RightPanel.',
+        'Custom link renderers must forward all linkProps to preserve aria-current, labels, handlers, and className.',
+        'Auth provider buttons keep the visible provider affordance separate from the accessible button name.',
+        'Route-owned panel views should expose headings inside their rendered panel content.',
+        'Reduced-motion behavior remains delegated to Meda shell motion tokens.',
+    ],
+};
+export const nextRecipes = [nextAppShellRecipe];

--- a/dist/shell/app-shell.d.ts
+++ b/dist/shell/app-shell.d.ts
@@ -1,12 +1,15 @@
 import type { ReactNode } from 'react';
-import type { AppShellAuthConfig, AppShellContextRailConfig, AppShellIconRailConfig, AppShellRightPanelConfig } from './types.js';
+import type { AppShellAuthBranding, AppShellAuthConfig, AppShellContextRailConfig, AppShellIconRailConfig, AppShellRightPanelConfig } from './types.js';
 interface AppShellBaseProps {
     children: ReactNode;
     className?: string;
 }
 export type AppShellProps = AppShellBaseProps & ({
     variant: 'auth';
-    auth: AppShellAuthConfig;
+    auth?: AppShellAuthConfig;
+    branding?: AppShellAuthBranding;
+    preview?: ReactNode;
+    actions?: ReactNode;
 } | {
     variant: 'workspace';
     iconRail?: AppShellIconRailConfig;

--- a/dist/shell/app-shell.js
+++ b/dist/shell/app-shell.js
@@ -14,12 +14,24 @@ export function AppShell(props) {
     const wrapper = (content) => (_jsx("div", { "data-meda-app": activeAppId, "data-meda-workspace": workspace.id, "data-meda-variant": props.variant, className: cn(heightClass, 'bg-background text-foreground', props.className), children: content }));
     switch (props.variant) {
         case 'auth':
-            return wrapper(_jsx(AppShellAuth, { ...props.auth, children: props.children }));
+            return wrapper(_jsx(AppShellAuth, { ...resolveAuthConfig(props), children: props.children }));
         case 'workspace':
             return wrapper(_jsx(AppShellWorkspace, { iconRail: props.iconRail, contextRail: props.contextRail, rightPanel: props.rightPanel, globalActions: props.globalActions, children: props.children }));
         case 'chat':
             return wrapper(_jsx(AppShellChat, { globalActions: props.globalActions, children: props.children }));
     }
+}
+function resolveAuthConfig(props) {
+    const { auth, branding } = props;
+    return {
+        title: auth?.title ?? branding?.appName ?? branding?.brandName ?? 'Sign in',
+        description: auth?.description ?? branding?.tagline,
+        brandName: auth?.brandName ?? branding?.brandName,
+        brandMark: auth?.brandMark ?? branding?.brandMark,
+        eyebrow: auth?.eyebrow,
+        preview: auth?.preview ?? props.preview,
+        actions: auth?.actions ?? props.actions,
+    };
 }
 export function AppShellBody({ children, className }) {
     return (_jsx("div", { className: cn('relative flex h-[calc(100vh-var(--shell-header-height))] overflow-hidden', className), children: children }));

--- a/dist/shell/context-rail.js
+++ b/dist/shell/context-rail.js
@@ -15,7 +15,7 @@ import { jsx as _jsx, jsxs as _jsxs, Fragment as _Fragment } from "react/jsx-run
  * once <AppShellBody> ships as a ResizableShell Group.
  */
 import { PanelLeftClose, PanelLeftOpen } from 'lucide-react';
-import { useId, useRef, useState } from 'react';
+import { Fragment, useId, useRef, useState } from 'react';
 import { cn } from '../lib/utils.js';
 import { useMedaShell } from './shell-provider.js';
 import { useShellViewport } from './use-shell-viewport.js';
@@ -120,9 +120,15 @@ export function ContextRail({ appId, module, hidden = false, collapsible = true,
                                 : 'text-muted-foreground hover:bg-accent hover:text-foreground');
                             const IconComp = item.icon;
                             const inner = (_jsxs(_Fragment, { children: [_jsx(IconComp, { size: 16, "aria-hidden": "true", className: "shrink-0" }), _jsx("span", { className: "truncate", children: item.label }), item.shortcut && (_jsx("kbd", { className: "ml-auto font-mono text-[10px] text-muted-foreground", children: item.shortcut }))] }));
+                            const linkProps = {
+                                href: item.to,
+                                'aria-current': isActive ? 'page' : undefined,
+                                className: klass,
+                                children: inner,
+                            };
                             if (renderLink) {
-                                return renderLink({ item, isActive, className: klass, children: inner });
+                                return (_jsx(Fragment, { children: renderLink({ item, isActive, className: klass, children: inner, linkProps }) }, item.id));
                             }
-                            return (_jsx("a", { href: item.to, "aria-current": isActive ? 'page' : undefined, className: klass, children: inner }, item.id));
+                            return _jsx("a", { ...linkProps }, item.id);
                         }) })), module.render?.({ workspaceId: ctx.workspace.id, appId })] }), !collapsed && (_jsx(ResizeHandle, { currentWidth: width, onResize: handleResize, onCommit: handleCommit }))] }));
 }

--- a/dist/shell/icon-rail.d.ts
+++ b/dist/shell/icon-rail.d.ts
@@ -1,5 +1,5 @@
 import type { LucideIcon } from 'lucide-react';
-import type { ReactNode } from 'react';
+import type { AnchorHTMLAttributes, ReactNode } from 'react';
 export interface IconRailItem {
     id: string;
     label: string;
@@ -12,6 +12,7 @@ export interface IconRailRenderLinkArgs {
     isActive: boolean;
     className: string;
     children: ReactNode;
+    linkProps: AnchorHTMLAttributes<HTMLAnchorElement>;
 }
 export interface IconRailProps {
     mainItems: IconRailItem[];

--- a/dist/shell/icon-rail.js
+++ b/dist/shell/icon-rail.js
@@ -29,9 +29,16 @@ export function IconRail({ mainItems, utilityItems = [], footer, activeId, rende
         const klass = itemClass(isActive);
         const IconComp = item.icon;
         const inner = (_jsxs(_Fragment, { children: [_jsx(IconComp, { size: 22, "aria-hidden": "true" }), item.badge ? _jsx("span", { className: "absolute right-1 top-1", children: item.badge }) : null] }));
+        const linkProps = {
+            href: item.to,
+            'aria-label': item.label,
+            'aria-current': isActive ? 'page' : undefined,
+            className: 'contents',
+            children: inner,
+        };
         const linkContent = renderLink ? (
         // renderLink consumers receive the className so they can apply it themselves
-        renderLink({ item, isActive, className: klass, children: inner })) : (_jsx("a", { href: item.to, "aria-label": item.label, "aria-current": isActive ? 'page' : undefined, className: "contents", children: inner }));
+        renderLink({ item, isActive, className: klass, children: inner, linkProps })) : (_jsx("a", { ...linkProps }));
         return (_jsxs(Tooltip, { children: [_jsx(TooltipTrigger, { render: _jsx("span", { "data-testid": `icon-rail-trigger-${item.id}`, className: klass, children: linkContent }) }), _jsx(TooltipContent, { side: "right", children: item.label })] }, item.id));
     };
     return (_jsx(TooltipProvider, { children: _jsxs("nav", { "data-testid": "icon-rail", "aria-label": "Primary", className: cn('flex h-full w-[var(--shell-rail-width)] shrink-0 flex-col items-center bg-shell-rail py-3.5', className), children: [_jsx("div", { className: "flex flex-col items-center gap-1", children: mainItems.map(renderItem) }), utilityItems.length > 0 && (_jsxs(_Fragment, { children: [_jsx(RailDivider, { pinnedBottom: pinnedBottom, onToggle: () => setPinnedBottom((prev) => !prev) }), _jsx("div", { "data-testid": "utility-items-wrapper", className: cn('flex flex-col items-center gap-1', pinnedBottom && 'mt-auto'), children: utilityItems.map(renderItem) })] })), footer && (_jsx("div", { className: cn('pt-3', pinnedBottom || utilityItems.length === 0 ? 'mt-auto' : ''), children: footer }))] }) }));

--- a/dist/shell/index.d.ts
+++ b/dist/shell/index.d.ts
@@ -7,6 +7,7 @@ export { ContextRail } from './context-rail.js';
 export type { DragModeBannerProps } from './drag-mode-banner.js';
 export { DragModeBanner } from './drag-mode-banner.js';
 export * as Extras from './extras/index.js';
+export type { IconRailItem, IconRailProps, IconRailRenderLinkArgs } from './icon-rail.js';
 export { IconRail, RailDivider } from './icon-rail.js';
 export type { ShellStorageAdapter } from './layout-state.js';
 export { createLocalStorageAdapter } from './layout-state.js';

--- a/dist/shell/index.d.ts
+++ b/dist/shell/index.d.ts
@@ -1,3 +1,5 @@
+export type { AuthMessageProps, AuthOneTapSlotProps, AuthProvider, AuthProviderButtonProps, AuthProviderListProps, } from '../auth/index.js';
+export { AuthError, AuthNotice, AuthOneTapSlot, AuthProviderButton, AuthProviderList, } from '../auth/index.js';
 export { AppShell, AppShellBody } from './app-shell.js';
 export type { CommandGroupDefinition } from './command-palette.js';
 export { CommandPalette, useCommandGroup, useCommands } from './command-palette.js';
@@ -23,5 +25,5 @@ export type { MedaShellProviderProps } from './shell-provider.js';
 export { MedaShellProvider, useMedaShell, useShellSelection } from './shell-provider.js';
 export { DefaultThemeProvider, ThemeToggle, useTheme } from './theme.js';
 export { NextThemesAdapter } from './theme-next-themes.js';
-export type { AppDefinition, AppShellAuthConfig, AppShellContextRailConfig, AppShellIconRailConfig, AppShellRightPanelConfig, AppShellVariant, CommandDefinition, ContextItem, ContextModule, MobileBottomNavItem, PanelMode, PanelView, ShellLinkRenderArgs, ShellMainLayout, ShellRenderContext, ShellViewport, ThemeAdapter, WorkspaceDefinition, } from './types.js';
+export type { AppDefinition, AppShellAuthBranding, AppShellAuthConfig, AppShellContextRailConfig, AppShellIconRailConfig, AppShellRightPanelConfig, AppShellVariant, CommandDefinition, ContextItem, ContextModule, MobileBottomNavItem, PanelMode, PanelView, ShellLinkRenderArgs, ShellMainLayout, ShellRenderContext, ShellViewport, ThemeAdapter, WorkspaceDefinition, } from './types.js';
 export { useShellViewport } from './use-shell-viewport.js';

--- a/dist/shell/index.js
+++ b/dist/shell/index.js
@@ -3,6 +3,7 @@
 // the directive (see test/nextjs-consumer.test.ts). Each underlying component
 // file carries its own 'use client' — Next traces through the barrel and
 // applies them per-component. The barrel itself is just a re-exporter.
+export { AuthError, AuthNotice, AuthOneTapSlot, AuthProviderButton, AuthProviderList, } from '../auth/index.js';
 // Layout
 export { AppShell, AppShellBody } from './app-shell.js';
 // Command palette

--- a/dist/shell/index.js
+++ b/dist/shell/index.js
@@ -13,7 +13,6 @@ export { ContextRail } from './context-rail.js';
 export { DragModeBanner } from './drag-mode-banner.js';
 // Extras (legacy components ported during Phase 15 — opt-in for apps that need them)
 export * as Extras from './extras/index.js';
-// Rails + main + panel
 export { IconRail, RailDivider } from './icon-rail.js';
 // Storage adapter (consumers may want to provide their own)
 export { createLocalStorageAdapter } from './layout-state.js';

--- a/dist/shell/internal/mobile-drawers.js
+++ b/dist/shell/internal/mobile-drawers.js
@@ -34,15 +34,22 @@ const menuItemClassName = 'flex items-center gap-2 rounded-md px-3 py-2 text-sm 
 function MenuDrawerItem({ item, isActive, onClose, renderLink, }) {
     const Icon = item.icon;
     const children = (_jsxs(_Fragment, { children: [_jsx(Icon, { size: 18, "aria-hidden": "true" }), _jsx("span", { children: item.label })] }));
+    const className = cn(menuItemClassName, isActive && 'bg-accent text-foreground');
+    const linkProps = {
+        href: item.to,
+        className,
+        children,
+    };
     if (renderLink) {
         return closeAfterLinkClick(renderLink({
             item,
             isActive,
-            className: cn(menuItemClassName, isActive && 'bg-accent text-foreground'),
+            className,
             children,
+            linkProps,
         }), onClose);
     }
-    return (_jsx("a", { href: item.to, onClick: onClose, className: menuItemClassName, children: children }));
+    return closeAfterLinkClick(_jsx("a", { ...linkProps }), onClose);
 }
 function closeAfterLinkClick(link, onClose) {
     if (!isValidElement(link)) {

--- a/dist/shell/primitives.d.ts
+++ b/dist/shell/primitives.d.ts
@@ -1,0 +1,9 @@
+export type { ShellStorageAdapter } from './layout-state.js';
+export { createLocalStorageAdapter } from './layout-state.js';
+export type { PanelViewsProviderProps } from './panel-views-provider.js';
+export { PanelViewsProvider } from './panel-views-provider.js';
+export { ResizableHandle, ResizableShell, ResizableShellPanel } from './resizable-shell.js';
+export type { MedaShellProviderProps } from './shell-provider.js';
+export { MedaShellProvider, useMedaShell, useShellSelection } from './shell-provider.js';
+export type { AppDefinition, CommandDefinition, ContextItem, ContextModule, MobileBottomNavItem, PanelMode, PanelView, ShellLinkRenderArgs, ShellRenderContext, ShellViewport, ThemeAdapter, WorkspaceDefinition, } from './types.js';
+export { useShellViewport } from './use-shell-viewport.js';

--- a/dist/shell/primitives.js
+++ b/dist/shell/primitives.js
@@ -1,0 +1,7 @@
+// State and layout primitives for consumers that want Meda shell behavior
+// without importing the full styled shell barrel.
+export { createLocalStorageAdapter } from './layout-state.js';
+export { PanelViewsProvider } from './panel-views-provider.js';
+export { ResizableHandle, ResizableShell, ResizableShellPanel } from './resizable-shell.js';
+export { MedaShellProvider, useMedaShell, useShellSelection } from './shell-provider.js';
+export { useShellViewport } from './use-shell-viewport.js';

--- a/dist/shell/right-panel.d.ts
+++ b/dist/shell/right-panel.d.ts
@@ -1,3 +1,4 @@
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
 import type { PanelMode, PanelView } from './types.js';
 export interface RightPanelProps {
     /** Views to render as tabs in the panel header. */
@@ -10,6 +11,16 @@ export interface RightPanelProps {
      * If only ['panel'], the cycle button is hidden.
      */
     modes?: PanelMode[];
+    renderTab?: (args: RightPanelTabRenderArgs) => ReactNode;
     className?: string;
 }
-export declare function RightPanel({ panelViews, defaultView, modes, className, }: RightPanelProps): import("react/jsx-runtime").JSX.Element | null;
+export interface RightPanelTabRenderArgs {
+    view: PanelView;
+    isActive: boolean;
+    buttonProps: RightPanelTabButtonProps;
+    children: ReactNode;
+}
+export type RightPanelTabButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+    'data-active'?: boolean;
+};
+export declare function RightPanel({ panelViews, defaultView, modes, renderTab, className, }: RightPanelProps): import("react/jsx-runtime").JSX.Element | null;

--- a/dist/shell/right-panel.js
+++ b/dist/shell/right-panel.js
@@ -1,5 +1,5 @@
 'use client';
-import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
+import { jsx as _jsx, Fragment as _Fragment, jsxs as _jsxs } from "react/jsx-runtime";
 /**
  * RightPanel — spec §12
  *
@@ -16,7 +16,7 @@ import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
  * TODO(phase-15-refactor): swap to ResizableShell once AppShellBody is a PanelGroup
  */
 import { Maximize2, Minimize2, X } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { Fragment, useEffect, useRef, useState } from 'react';
 import { cn } from '../lib/utils.js';
 import { useResolvedPanelViews } from './panel-views-provider.js';
 import { useMedaShell } from './shell-provider.js';
@@ -63,7 +63,7 @@ function ResizeHandle({ currentWidth, onResize, onCommit }) {
 // ---------------------------------------------------------------------------
 // RightPanel
 // ---------------------------------------------------------------------------
-export function RightPanel({ panelViews = EMPTY_PANEL_VIEWS, defaultView, modes = ['panel', 'expanded', 'fullscreen'], className, }) {
+export function RightPanel({ panelViews = EMPTY_PANEL_VIEWS, defaultView, modes = ['panel', 'expanded', 'fullscreen'], renderTab, className, }) {
     const band = useShellViewport();
     const ctx = useMedaShell();
     const { mode, activeView, width, setMode, setActiveView, setWidth } = ctx.panel;
@@ -132,8 +132,20 @@ export function RightPanel({ panelViews = EMPTY_PANEL_VIEWS, defaultView, modes 
     return (_jsx("aside", { "data-meda-panel-mode": mode, "aria-hidden": mode === 'closed' ? 'true' : undefined, className: cn('relative h-full shrink-0 overflow-hidden border-l border-shell-border bg-shell-panel', 'transition-[width] ease-[var(--motion-ease)] duration-[var(--motion-panel)]', mode === 'fullscreen' && 'fixed inset-0 h-screen w-screen border-none', zIndexClass, className), style: widthStyle, children: mode !== 'closed' && (_jsxs("div", { className: "flex h-full flex-col", children: [_jsxs("div", { className: "flex items-center justify-between border-b border-shell-border px-3 py-2", children: [_jsx("div", { className: "flex items-center gap-1", children: resolvedPanelViews.map((view) => {
                                 const isActive = view.id === activeView;
                                 const Icon = view.icon;
-                                return (_jsxs("button", { type: "button", "aria-current": isActive ? 'true' : undefined, onClick: () => setActiveView(view.id), className: cn('inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium transition-colors', isActive
+                                const children = (_jsxs(_Fragment, { children: [_jsx(Icon, { size: 14, "aria-hidden": "true" }), _jsx("span", { children: view.label })] }));
+                                const buttonProps = {
+                                    type: 'button',
+                                    'aria-current': isActive ? 'true' : undefined,
+                                    'data-active': isActive || undefined,
+                                    onClick: () => setActiveView(view.id),
+                                    className: cn('inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium transition-colors', isActive
                                         ? 'bg-accent text-accent-foreground'
-                                        : 'text-muted-foreground hover:bg-accent hover:text-foreground'), children: [_jsx(Icon, { size: 14, "aria-hidden": "true" }), _jsx("span", { children: view.label })] }, view.id));
+                                        : 'text-muted-foreground hover:bg-accent hover:text-foreground'),
+                                    children,
+                                };
+                                if (renderTab) {
+                                    return (_jsx(Fragment, { children: renderTab({ view, isActive, buttonProps, children }) }, view.id));
+                                }
+                                return _jsx("button", { ...buttonProps }, view.id);
                             }) }), _jsxs("div", { className: "flex items-center gap-1", children: [modes.length > 1 && (_jsx("button", { type: "button", "aria-label": cycleAriaLabel, onClick: cycleOpenMode, className: "inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground", children: mode === 'fullscreen' ? (_jsx(Minimize2, { size: 14, "aria-hidden": "true" })) : (_jsx(Maximize2, { size: 14, "aria-hidden": "true" })) })), _jsx("button", { type: "button", "aria-label": "Close panel", onClick: () => setMode('closed'), className: "inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground", children: _jsx(X, { size: 14, "aria-hidden": "true" }) })] })] }), _jsx("div", { className: "flex-1 overflow-y-auto", children: activePanelView != null ? (activePanelView.render(renderCtx)) : (_jsx("div", { className: "p-4 text-muted-foreground text-sm", children: "No panel view selected" })) }), mode === 'panel' && (_jsx(ResizeHandle, { currentWidth: resolvedWidth, onResize: handleResize, onCommit: handleCommit }))] })) }));
 }

--- a/dist/shell/types.d.ts
+++ b/dist/shell/types.d.ts
@@ -1,5 +1,5 @@
 import type { LucideIcon } from 'lucide-react';
-import type { ReactNode } from 'react';
+import type { AnchorHTMLAttributes, ReactNode } from 'react';
 export interface AppDefinition {
     id: string;
     label: string;
@@ -49,6 +49,7 @@ export interface ShellLinkRenderArgs {
     isActive: boolean;
     className: string;
     children: ReactNode;
+    linkProps: AnchorHTMLAttributes<HTMLAnchorElement>;
 }
 export interface CommandDefinition {
     id: string;

--- a/dist/shell/types.d.ts
+++ b/dist/shell/types.d.ts
@@ -101,3 +101,9 @@ export interface AppShellAuthConfig {
     preview?: ReactNode;
     actions?: ReactNode;
 }
+export interface AppShellAuthBranding {
+    brandName?: ReactNode;
+    brandMark?: ReactNode;
+    appName?: ReactNode;
+    tagline?: ReactNode;
+}

--- a/dist/theme/index.d.ts
+++ b/dist/theme/index.d.ts
@@ -1,0 +1,1 @@
+export { createMedaThemeCss, defineMedaTheme, type MedaThemeConfig, type MedaThemeDefinition, type MedaThemeMode, type MedaThemeModeConfig, type MedaThemeTokenMap, } from './theme-bridge.js';

--- a/dist/theme/index.js
+++ b/dist/theme/index.js
@@ -1,0 +1,1 @@
+export { createMedaThemeCss, defineMedaTheme, } from './theme-bridge.js';

--- a/dist/theme/theme-bridge.d.ts
+++ b/dist/theme/theme-bridge.d.ts
@@ -1,0 +1,21 @@
+export type MedaThemeMode = 'light' | 'dark';
+export type MedaThemeTokenMap = Record<string, string | undefined>;
+export interface MedaThemeModeConfig {
+    colors?: MedaThemeTokenMap;
+    fonts?: MedaThemeTokenMap;
+    tokens?: MedaThemeTokenMap;
+}
+export interface MedaThemeConfig extends MedaThemeModeConfig {
+    appId: string;
+    selector?: string;
+    light?: MedaThemeModeConfig;
+    dark?: MedaThemeModeConfig;
+}
+export interface MedaThemeDefinition {
+    appId: string;
+    selector: string;
+    light: Required<MedaThemeModeConfig>;
+    dark: Required<MedaThemeModeConfig>;
+}
+export declare function defineMedaTheme(config: MedaThemeConfig): MedaThemeDefinition;
+export declare function createMedaThemeCss(theme: MedaThemeDefinition): string;

--- a/dist/theme/theme-bridge.js
+++ b/dist/theme/theme-bridge.js
@@ -1,0 +1,52 @@
+const MODE_KEYS = ['colors', 'fonts', 'tokens'];
+function assertAppId(appId) {
+    if (!/^[a-zA-Z0-9_-]+$/.test(appId)) {
+        throw new Error('Meda theme appId must contain only letters, numbers, underscores, or dashes.');
+    }
+}
+function toCssVariableName(group, key) {
+    const normalized = key.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`);
+    if (normalized.startsWith('--')) {
+        return normalized;
+    }
+    if (group === 'fonts') {
+        return `--font-${normalized}`;
+    }
+    return `--${normalized}`;
+}
+function mergeModeConfig(base, mode = {}) {
+    return {
+        colors: { ...base.colors, ...mode.colors },
+        fonts: { ...base.fonts, ...mode.fonts },
+        tokens: { ...base.tokens, ...mode.tokens },
+    };
+}
+export function defineMedaTheme(config) {
+    assertAppId(config.appId);
+    const base = {
+        colors: config.colors ?? {},
+        fonts: config.fonts ?? {},
+        tokens: config.tokens ?? {},
+    };
+    return {
+        appId: config.appId,
+        selector: config.selector ?? `[data-meda-app="${config.appId}"]`,
+        light: mergeModeConfig(base, config.light),
+        dark: mergeModeConfig(base, config.dark),
+    };
+}
+function entriesForMode(mode) {
+    return MODE_KEYS.flatMap((group) => Object.entries(mode[group])
+        .filter((entry) => typeof entry[1] === 'string')
+        .map(([key, value]) => [toCssVariableName(group, key), value])).sort(([left], [right]) => left.localeCompare(right));
+}
+function renderBlock(selector, entries) {
+    const declarations = entries.map(([key, value]) => `  ${key}: ${value};`).join('\n');
+    return `${selector} {\n${declarations}\n}`;
+}
+export function createMedaThemeCss(theme) {
+    const lightEntries = entriesForMode(theme.light);
+    const darkEntries = entriesForMode(theme.dark);
+    const darkSelector = `${theme.selector}.dark, ${theme.selector}[data-theme="dark"]`;
+    return [renderBlock(theme.selector, lightEntries), renderBlock(darkSelector, darkEntries)].join('\n\n');
+}

--- a/docs/STORIES.md
+++ b/docs/STORIES.md
@@ -81,3 +81,14 @@ Consumers compose one `<AppShell>` with a config:
 ```
 
 The variant decides which chrome renders. The viewport decides whether desktop or mobile chrome is used internally. Consumers do not import `MobileHeader`, `MobileBottomNav`, or `MobileDrawers` directly. Those are no longer exported.
+
+## Adoption recipes
+
+Copyable recipes should document both accessibility and composition contracts. At minimum, recipes that wrap `AppShell` need to say which props must be forwarded (`linkProps`, trigger props, tab props), where accessible names/headings come from, and which provider owns shell state.
+
+Keep recipe stories and docs close to the consumer workflow:
+
+- show framework adapters like `next/link` through render callbacks, not by replacing Meda state;
+- pass initial `rightPanel.panelViews` synchronously when they are known at layout render time;
+- use `PanelViewsProvider` for nested route registrations that need cleanup on unmount;
+- include reduced-motion and keyboard behavior in the recipe notes.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,14 @@
       "types": "./dist/brand/index.d.ts",
       "default": "./dist/brand/index.js"
     },
+    "./auth": {
+      "types": "./dist/auth/index.d.ts",
+      "default": "./dist/auth/index.js"
+    },
+    "./auth/better-auth": {
+      "types": "./dist/auth/better-auth.d.ts",
+      "default": "./dist/auth/better-auth.js"
+    },
     "./shell": {
       "types": "./dist/shell/index.d.ts",
       "default": "./dist/shell/index.js"

--- a/package.json
+++ b/package.json
@@ -80,6 +80,14 @@
     },
     "./styles/tokens": {
       "default": "./dist/styles/tokens.css"
+    },
+    "./shell/primitives": {
+      "types": "./dist/shell/primitives.d.ts",
+      "default": "./dist/shell/primitives.js"
+    },
+    "./recipes/next": {
+      "types": "./dist/recipes/next.d.ts",
+      "default": "./dist/recipes/next.js"
     }
   },
   "sideEffects": [

--- a/package.json
+++ b/package.json
@@ -88,6 +88,10 @@
     "./recipes/next": {
       "types": "./dist/recipes/next.d.ts",
       "default": "./dist/recipes/next.js"
+    },
+    "./theme": {
+      "types": "./dist/theme/index.d.ts",
+      "default": "./dist/theme/index.js"
     }
   },
   "sideEffects": [

--- a/registry/README.md
+++ b/registry/README.md
@@ -11,6 +11,7 @@ Current items:
 - `meda-shell`
 - `meda-shell-state`
 - `meda-workbench-layout`
+- `meda-next-app-shell`
 - `meda-marketing`
 - `meda-marketing-callout`
 - `meda-marketing-contact`

--- a/registry/r/meda-next-app-shell.json
+++ b/registry/r/meda-next-app-shell.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "meda-next-app-shell",
+  "type": "registry:block",
+  "title": "Meda Next AppShell",
+  "description": "Install a copyable Next.js App Router shell adapter with next/link routing, route-owned panel views, and auth controls.",
+  "dependencies": ["@medalsocial/meda", "lucide-react"],
+  "files": [
+    {
+      "path": "registry/meda/meda-next-app-shell/meda-next-app-shell.tsx",
+      "content": "export { nextAppShellRecipe as medaNextAppShellRecipe } from '@medalsocial/meda/recipes/next'\n",
+      "type": "registry:block",
+      "target": "components/meda/meda-next-app-shell.tsx"
+    }
+  ],
+  "meta": {
+    "peerDependencies": ["next", "react", "react-dom"],
+    "cssVars": ["@medalsocial/meda/styles.css"],
+    "accessibility": [
+      "Forward all linkProps from rail render callbacks.",
+      "Panel views should include a visible or visually-hidden heading.",
+      "Auth provider buttons preserve accessible button names."
+    ]
+  }
+}

--- a/registry/r/meda-next-app-shell.json
+++ b/registry/r/meda-next-app-shell.json
@@ -4,18 +4,27 @@
   "type": "registry:block",
   "title": "Meda Next AppShell",
   "description": "Install a copyable Next.js App Router shell adapter with next/link routing, route-owned panel views, and auth controls.",
-  "dependencies": ["@medalsocial/meda", "lucide-react"],
+  "dependencies": [
+    "@medalsocial/meda",
+    "lucide-react"
+  ],
   "files": [
     {
       "path": "registry/meda/meda-next-app-shell/meda-next-app-shell.tsx",
-      "content": "export { nextAppShellRecipe as medaNextAppShellRecipe } from '@medalsocial/meda/recipes/next'\n",
+      "content": "'use client'\n\nimport Link from 'next/link'\nimport type { ComponentProps, ReactNode } from 'react'\nimport {\n  AppShell,\n  AuthError,\n  AuthNotice,\n  AuthOneTapSlot,\n  AuthProviderButton,\n  AuthProviderList,\n  MedaShellProvider,\n  PanelViewsProvider,\n  type AppDefinition,\n  type IconRailItem,\n  type PanelView,\n  type WorkspaceDefinition,\n} from '@medalsocial/meda/shell'\n\nexport function MedaNextWorkspaceShell({\n  workspace,\n  apps,\n  iconItems,\n  activeIconId,\n  panelViews = [],\n  defaultPanelView,\n  children,\n}: {\n  workspace: WorkspaceDefinition\n  apps: AppDefinition[]\n  iconItems: IconRailItem[]\n  activeIconId?: string\n  panelViews?: PanelView[]\n  defaultPanelView?: string\n  children: ReactNode\n}) {\n  return (\n    <MedaShellProvider workspace={workspace} apps={apps}>\n      <AppShell\n        variant=\"workspace\"\n        iconRail={{\n          mainItems: iconItems,\n          activeId: activeIconId,\n          renderLink: ({ item, linkProps }) => (\n            <Link {...linkProps} href={item.to} prefetch />\n          ),\n        }}\n        rightPanel={{ panelViews, defaultView: defaultPanelView }}\n      >\n        <PanelViewsProvider views={panelViews} defaultView={defaultPanelView}>\n          {children}\n        </PanelViewsProvider>\n      </AppShell>\n    </MedaShellProvider>\n  )\n}\n\nexport function MedaNextAuthShell({\n  brandName,\n  brandMark,\n  appName,\n  tagline,\n  preview,\n  error,\n  notice,\n  onGoogleSignIn,\n}: {\n  brandName: ReactNode\n  brandMark?: ReactNode\n  appName?: ReactNode\n  tagline?: ReactNode\n  preview?: ReactNode\n  error?: ReactNode\n  notice?: ReactNode\n  onGoogleSignIn: ComponentProps<typeof AuthProviderButton>['onClick']\n}) {\n  return (\n    <MedaShellProvider workspace={{ id: 'auth', name: 'Auth', icon: brandMark }} apps={[]}>\n      <AppShell\n        variant=\"auth\"\n        branding={{ brandName, brandMark, appName, tagline }}\n        preview={preview}\n      >\n        <AuthProviderList>\n          <AuthProviderButton\n            provider=\"google\"\n            label=\"Continue with Google\"\n            onClick={onGoogleSignIn}\n          />\n        </AuthProviderList>\n        <AuthNotice>{notice}</AuthNotice>\n        <AuthError>{error}</AuthError>\n        <AuthOneTapSlot />\n      </AppShell>\n    </MedaShellProvider>\n  )\n}\n",
       "type": "registry:block",
       "target": "components/meda/meda-next-app-shell.tsx"
     }
   ],
   "meta": {
-    "peerDependencies": ["next", "react", "react-dom"],
-    "cssVars": ["@medalsocial/meda/styles.css"],
+    "peerDependencies": [
+      "next",
+      "react",
+      "react-dom"
+    ],
+    "cssVars": [
+      "@medalsocial/meda/styles.css"
+    ],
     "accessibility": [
       "Forward all linkProps from rail render callbacks.",
       "Panel views should include a visible or visually-hidden heading.",

--- a/registry/r/meda-next-app-shell.json
+++ b/registry/r/meda-next-app-shell.json
@@ -20,6 +20,12 @@
       "Forward all linkProps from rail render callbacks.",
       "Panel views should include a visible or visually-hidden heading.",
       "Auth provider buttons preserve accessible button names."
+    ],
+    "composition": [
+      "MedaShellProvider owns workspace/app context.",
+      "AppShell receives rightPanel views on first render.",
+      "PanelViewsProvider keeps route-owned panel registrations available to nested content.",
+      "Next Link adapters forward Meda linkProps before adding framework-specific props."
     ]
   }
 }

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -50,6 +50,21 @@
     },
     {
       "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+      "name": "meda-next-app-shell",
+      "type": "registry:block",
+      "title": "Meda Next AppShell",
+      "description": "Install a copyable Next.js App Router shell adapter.",
+      "dependencies": ["@medalsocial/meda", "lucide-react"],
+      "files": [
+        {
+          "path": "registry/meda/meda-next-app-shell/meda-next-app-shell.tsx",
+          "type": "registry:block",
+          "target": "components/meda/meda-next-app-shell.tsx"
+        }
+      ]
+    },
+    {
+      "$schema": "https://ui.shadcn.com/schema/registry-item.json",
       "name": "meda-marketing",
       "type": "registry:block",
       "title": "Meda Marketing",

--- a/registry/scripts/validate-registry.mjs
+++ b/registry/scripts/validate-registry.mjs
@@ -23,6 +23,13 @@ function assert(condition, message) {
   }
 }
 
+function assertStringList(value, label) {
+  assert(Array.isArray(value) && value.length > 0, `${label} must be a non-empty array.`);
+  for (const item of value) {
+    assert(typeof item === 'string' && item.trim().length > 0, `${label} must contain strings.`);
+  }
+}
+
 const parsedFiles = new Map();
 
 for (const file of files) {
@@ -46,13 +53,17 @@ for (const [file, json] of parsedFiles.entries()) {
   );
   assert(Array.isArray(json?.dependencies), `${file} must declare dependencies.`);
   if (json.meta?.peerDependencies) {
-    assert(Array.isArray(json.meta.peerDependencies), `${file} peerDependencies must be an array.`);
+    assertStringList(json.meta.peerDependencies, `${file} peerDependencies`);
   }
   if (json.meta?.accessibility) {
-    assert(
-      Array.isArray(json.meta.accessibility) && json.meta.accessibility.length > 0,
-      `${file} accessibility metadata must be a non-empty array.`
-    );
+    assertStringList(json.meta.accessibility, `${file} accessibility metadata`);
+  }
+  if (json.meta?.composition) {
+    assertStringList(json.meta.composition, `${file} composition metadata`);
+  }
+  if (file === 'r/meda-next-app-shell.json') {
+    assertStringList(json.meta?.accessibility, `${file} accessibility metadata`);
+    assertStringList(json.meta?.composition, `${file} composition metadata`);
   }
   assert(
     Array.isArray(json?.files) && json.files.length > 0,

--- a/registry/scripts/validate-registry.mjs
+++ b/registry/scripts/validate-registry.mjs
@@ -10,6 +10,7 @@ const files = [
   'r/meda-shell.json',
   'r/meda-shell-state.json',
   'r/meda-workbench-layout.json',
+  'r/meda-next-app-shell.json',
   'r/meda-marketing.json',
   'r/meda-marketing-callout.json',
   'r/meda-marketing-contact.json',
@@ -44,6 +45,15 @@ for (const [file, json] of parsedFiles.entries()) {
     `${file} must include a registry type.`
   );
   assert(Array.isArray(json?.dependencies), `${file} must declare dependencies.`);
+  if (json.meta?.peerDependencies) {
+    assert(Array.isArray(json.meta.peerDependencies), `${file} peerDependencies must be an array.`);
+  }
+  if (json.meta?.accessibility) {
+    assert(
+      Array.isArray(json.meta.accessibility) && json.meta.accessibility.length > 0,
+      `${file} accessibility metadata must be a non-empty array.`
+    );
+  }
   assert(
     Array.isArray(json?.files) && json.files.length > 0,
     `${file} must include at least one file entry.`

--- a/src/__stories__/docs/Adoption.mdx
+++ b/src/__stories__/docs/Adoption.mdx
@@ -1,0 +1,88 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Get Started/Adoption" />
+
+# Adoption
+
+Meda's shell can be adopted at three layers:
+
+1. **Styled shell**: import `AppShell` and `MedaShellProvider` from `@medalsocial/meda/shell`.
+2. **Shell primitives**: import state providers and lower-level layout parts from `@medalsocial/meda/shell/primitives`.
+3. **Copyable recipes**: use `@medalsocial/meda/recipes/next` or the registry item when a host app needs local routing, analytics, or auth glue.
+
+## Next.js links
+
+Framework routers should preserve Meda's link props:
+
+```tsx
+import Link from 'next/link';
+import { AppShell } from '@medalsocial/meda/shell';
+
+<AppShell
+  variant="workspace"
+  iconRail={{
+    mainItems,
+    activeId,
+    renderLink: ({ item, linkProps }) => <Link {...linkProps} href={item.to} prefetch />,
+  }}
+>
+  {children}
+</AppShell>;
+```
+
+`linkProps` carries Meda's accessibility labels, active state, event handlers, and class names. Spread it before framework-specific props.
+
+## Route-owned panels
+
+When panel views are known at layout render time, pass them directly to `AppShell` so the right panel and mobile panel button exist on first paint:
+
+```tsx
+<AppShell variant="workspace" rightPanel={{ panelViews, defaultView: 'details' }}>
+  <PanelViewsProvider views={panelViews} defaultView="details">
+    {children}
+  </PanelViewsProvider>
+</AppShell>
+```
+
+Use `PanelViewsProvider` deeper in the tree when a route owns temporary views that should unregister on unmount.
+
+## Auth screens
+
+Use provider-neutral controls from `@medalsocial/meda/auth`, then wire sign-in behavior in the app:
+
+```tsx
+<AppShell
+  variant="auth"
+  branding={{ brandName: 'Housebets', brandMark, appName: 'Auto', tagline: 'by Housebets' }}
+>
+  <AuthProviderList>
+    <AuthProviderButton provider="google" label="Continue with Google" onClick={onGoogleSignIn} />
+  </AuthProviderList>
+  <AuthError>{error}</AuthError>
+</AppShell>
+```
+
+The optional `@medalsocial/meda/auth/better-auth` subpath provides `BetterAuthProviderButton`, `BetterAuthOneTap`, and `useBetterAuthLastLoginMethod` without coupling the base auth controls to better-auth.
+
+## Theme bridge
+
+Use `@medalsocial/meda/theme` to generate app-scoped CSS for brand token mapping:
+
+```ts
+const css = createMedaThemeCss(
+  defineMedaTheme({
+    appId: 'auto',
+    colors: {
+      primary: 'var(--hb-brand-500)',
+    },
+    dark: {
+      colors: {
+        background: 'var(--hb-base-900)',
+        foreground: 'var(--hb-base-50)',
+      },
+    },
+  })
+);
+```
+
+Mount the app root with `data-meda-app="auto"` and toggle `.dark` or `data-theme="dark"` on the same root.

--- a/src/__stories__/docs/GetStarted.mdx
+++ b/src/__stories__/docs/GetStarted.mdx
@@ -12,6 +12,7 @@ This Storybook is the canonical reference for components, tokens, and interactio
 
 - **Foundations**: colors, typography, spacing, radii, shadows, motion, z-index, iconography, and the Medal Social mark. Values are sourced from `src/styles/tokens.css`, which mirrors `00-design-system.lib.pen`.
 - **AppShell**: the canonical shell. One component, three variants — `workspace`, `auth`, `chat`. Mobile chrome is internal; viewport switch is automatic.
+- **Adoption APIs**: Next recipes, route-owned panel views, render boundaries, auth controls, and app-scoped theme bridges.
 - **Marketing**: callout, contact, and lead-magnet surfaces.
 - **Audio**: voice orb, level meter, and status pill.
 - **Studios**: Inspector and Timeline (seeds for upcoming Email, Workflow, Unifi, and Site studios).
@@ -19,8 +20,9 @@ This Storybook is the canonical reference for components, tokens, and interactio
 ## Where to start
 
 1. [Installation](?path=/docs/get-started-installation--docs): pull the package into a host app.
-2. [Theming](?path=/docs/get-started-theming--docs): wire up canonical tokens.
-3. [Foundations / Color](?path=/docs/foundations-color--docs): review the brand ramp and semantic mapping.
+2. [Adoption](?path=/docs/get-started-adoption--docs): wire AppShell into an existing app.
+3. [Theming](?path=/docs/get-started-theming--docs): wire up canonical tokens.
+4. [Foundations / Color](?path=/docs/foundations-color--docs): review the brand ramp and semantic mapping.
 
 ## Conventions
 

--- a/src/__stories__/docs/Installation.mdx
+++ b/src/__stories__/docs/Installation.mdx
@@ -12,7 +12,7 @@ Meda is published to npm as `@medalsocial/meda`. It supports React 19+ and ships
 pnpm add @medalsocial/meda lucide-react
 ```
 
-`lucide-react` is a peer dependency.
+`lucide-react`, `react`, and `react-dom` are peer dependencies. Install `next-themes` only when using the optional `themeAdapter="next-themes"` shell bridge.
 
 ## Import the runtime CSS
 
@@ -31,22 +31,25 @@ This pulls in:
 ## Use a component
 
 ```tsx
-import { AppShell, AppShellBody, MedaShellProvider, ShellHeader } from '@medalsocial/meda/shell';
-import { Inbox } from 'lucide-react';
+import { AppShell, MedaShellProvider } from '@medalsocial/meda/shell';
+import { Inbox, Settings } from 'lucide-react';
 
 const workspace = { id: 'workspace', name: 'Workspace' };
 const apps = [{ id: 'inbox', label: 'Inbox', icon: Inbox }];
+const iconRail = {
+  mainItems: [{ id: 'inbox', label: 'Inbox', icon: Inbox, to: '/inbox' }],
+  utilityItems: [{ id: 'settings', label: 'Settings', icon: Settings, to: '/settings' }],
+};
 
 export function App() {
   return (
     <MedaShellProvider workspace={workspace} apps={apps}>
-      <AppShell>
-        <ShellHeader />
-        <AppShellBody>{/* app content */}</AppShellBody>
+      <AppShell variant="workspace" iconRail={iconRail}>
+        {/* app content */}
       </AppShell>
     </MedaShellProvider>
   );
 }
 ```
 
-Subpath imports such as `@medalsocial/meda/shell`, `/chat`, `/voice`, `/timeline`, and `/panel` keep the bundle focused.
+Subpath imports such as `@medalsocial/meda/shell`, `/shell/primitives`, `/auth`, `/auth/better-auth`, `/recipes/next`, `/theme`, `/chat`, `/voice`, `/timeline`, and `/panel` keep the bundle focused.

--- a/src/__stories__/docs/Theming.mdx
+++ b/src/__stories__/docs/Theming.mdx
@@ -39,3 +39,37 @@ Use `dark:bg-card`, `dark:text-foreground`, and related utilities without extra 
 ## Checking canonical values
 
 The [Foundations / Color](?path=/docs/foundations-color--docs) page shows the full primitive ramp and semantic mapping. Use it as the source of truth.
+
+## App token bridge
+
+Existing products can map their brand variables onto Meda's semantic tokens without copying long CSS blocks:
+
+```ts
+import { createMedaThemeCss, defineMedaTheme } from '@medalsocial/meda/theme';
+
+const autoTheme = defineMedaTheme({
+  appId: 'auto',
+  colors: {
+    primary: 'var(--hb-brand-500)',
+  },
+  fonts: {
+    body: 'var(--font-body)',
+  },
+  light: {
+    colors: {
+      background: 'var(--hb-base-50)',
+      foreground: 'var(--hb-base-950)',
+    },
+  },
+  dark: {
+    colors: {
+      background: 'var(--hb-base-900)',
+      foreground: 'var(--hb-base-50)',
+    },
+  },
+});
+
+const css = createMedaThemeCss(autoTheme);
+```
+
+Apply the generated CSS under `[data-meda-app="auto"]`, then set that attribute on the app root.

--- a/src/auth/auth-message.tsx
+++ b/src/auth/auth-message.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import type { HTMLAttributes, ReactNode } from 'react';
+import { cn } from '../lib/utils.js';
+
+export interface AuthMessageProps extends HTMLAttributes<HTMLDivElement> {
+  children?: ReactNode;
+}
+
+export function AuthError({ children, className, ...props }: AuthMessageProps) {
+  if (!children) {
+    return null;
+  }
+
+  return (
+    <div
+      role="alert"
+      className={cn(
+        'rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive',
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function AuthNotice({ children, className, ...props }: AuthMessageProps) {
+  if (!children) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn(
+        'rounded-md border border-border bg-muted/60 px-3 py-2 text-sm text-muted-foreground',
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+export interface AuthOneTapSlotProps extends HTMLAttributes<HTMLDivElement> {
+  children?: ReactNode;
+}
+
+export function AuthOneTapSlot({ children, className, ...props }: AuthOneTapSlotProps) {
+  return (
+    <div data-meda-auth-one-tap-slot="" className={cn('contents', className)} {...props}>
+      {children}
+    </div>
+  );
+}

--- a/src/auth/auth-provider-button.test.tsx
+++ b/src/auth/auth-provider-button.test.tsx
@@ -62,6 +62,30 @@ describe('auth controls', () => {
     consoleError.mockRestore();
   });
 
+  it('passes Meda button props into a custom rendered auth button', () => {
+    const onClick = vi.fn();
+    const customClick = vi.fn();
+
+    render(
+      <AuthProviderButton
+        provider="google"
+        label="Continue with Google"
+        lastUsed
+        onClick={onClick}
+        render={<button type="button" data-testid="custom-auth" onClick={customClick} />}
+      />
+    );
+
+    const button = screen.getByTestId('custom-auth');
+    expect(button).toHaveAttribute('data-provider', 'google');
+    expect(button).toHaveAttribute('data-last-used', 'true');
+    expect(button).toHaveAccessibleName('Continue with Google');
+
+    fireEvent.click(button);
+    expect(customClick).toHaveBeenCalledTimes(1);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
   it('renders auth messages only when content is supplied', () => {
     const { container } = render(
       <>

--- a/src/auth/auth-provider-button.test.tsx
+++ b/src/auth/auth-provider-button.test.tsx
@@ -1,0 +1,89 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { AuthError, AuthNotice, AuthOneTapSlot } from './auth-message.js';
+import { AuthProviderButton } from './auth-provider-button.js';
+import { AuthProviderList } from './auth-provider-list.js';
+
+describe('auth controls', () => {
+  it('renders provider buttons inside an accessible provider list', () => {
+    render(
+      <AuthProviderList>
+        <AuthProviderButton provider="google" label="Continue with Google" />
+      </AuthProviderList>
+    );
+
+    expect(screen.getByRole('list', { name: 'Authentication providers' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Continue with Google' })).toBeInTheDocument();
+  });
+
+  it('disables clicks while loading and exposes busy state', () => {
+    const onClick = vi.fn();
+
+    render(
+      <AuthProviderButton
+        provider="google"
+        label="Continue with Google"
+        loading
+        loadingLabel="Connecting..."
+        onClick={onClick}
+      />
+    );
+
+    const button = screen.getByRole('button', { name: 'Connecting...' });
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute('aria-busy', 'true');
+
+    fireEvent.click(button);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('shows the last-used affordance without replacing the accessible label', () => {
+    render(<AuthProviderButton provider="google" label="Continue with Google" lastUsed />);
+
+    expect(screen.getByRole('button', { name: 'Continue with Google' })).toBeInTheDocument();
+    expect(screen.getByText('Last used')).toBeInTheDocument();
+  });
+
+  it('does not warn when provider list children are wrapped as list items', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <AuthProviderList>
+        <AuthProviderButton key="google" provider="google" label="Continue with Google" />
+        <AuthProviderButton key="github" provider="github" label="Continue with GitHub" />
+      </AuthProviderList>
+    );
+
+    expect(consoleError).not.toHaveBeenCalledWith(
+      expect.stringContaining('Each child in a list should have a unique "key" prop'),
+      expect.anything()
+    );
+
+    consoleError.mockRestore();
+  });
+
+  it('renders auth messages only when content is supplied', () => {
+    const { container } = render(
+      <>
+        <AuthError>Sign-in failed</AuthError>
+        <AuthNotice>Restricted to team accounts</AuthNotice>
+        <AuthError />
+      </>
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Sign-in failed');
+    expect(screen.getByText('Restricted to team accounts')).toBeInTheDocument();
+    expect(container.querySelectorAll('[role="alert"]')).toHaveLength(1);
+  });
+
+  it('renders a stable one-tap slot container', () => {
+    render(
+      <AuthOneTapSlot data-testid="one-tap-slot">
+        <div>mounted provider content</div>
+      </AuthOneTapSlot>
+    );
+
+    expect(screen.getByTestId('one-tap-slot')).toHaveAttribute('data-meda-auth-one-tap-slot');
+    expect(screen.getByText('mounted provider content')).toBeInTheDocument();
+  });
+});

--- a/src/auth/auth-provider-button.tsx
+++ b/src/auth/auth-provider-button.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+import { cn } from '../lib/utils.js';
+
+export type AuthProvider = 'google' | (string & {});
+
+export interface AuthProviderButtonProps
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {
+  provider?: AuthProvider;
+  label: ReactNode;
+  icon?: ReactNode;
+  loading?: boolean;
+  loadingLabel?: ReactNode;
+  lastUsed?: boolean;
+  lastUsedLabel?: ReactNode;
+}
+
+export function AuthProviderButton({
+  provider,
+  label,
+  icon,
+  loading = false,
+  loadingLabel = 'Loading...',
+  lastUsed = false,
+  lastUsedLabel = 'Last used',
+  disabled,
+  className,
+  type = 'button',
+  ...props
+}: AuthProviderButtonProps) {
+  const resolvedIcon = icon ?? (provider === 'google' ? <GoogleIcon /> : null);
+  const isDisabled = disabled || loading;
+
+  return (
+    <button
+      type={type}
+      disabled={isDisabled}
+      aria-busy={loading || undefined}
+      data-provider={provider}
+      data-last-used={lastUsed || undefined}
+      className={cn(
+        'relative inline-flex min-h-11 w-full items-center justify-center gap-3 rounded-md border border-border bg-background px-4 py-2.5 text-sm font-medium text-foreground shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-60',
+        className
+      )}
+      {...props}
+    >
+      {resolvedIcon && (
+        <span className="flex size-5 shrink-0 items-center justify-center" aria-hidden="true">
+          {resolvedIcon}
+        </span>
+      )}
+      <span className="min-w-0 truncate">{loading ? loadingLabel : label}</span>
+      {lastUsed && !loading && (
+        <span
+          aria-hidden="true"
+          className="ml-auto shrink-0 rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground"
+        >
+          {lastUsedLabel}
+        </span>
+      )}
+    </button>
+  );
+}
+
+function GoogleIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="size-5" aria-hidden="true">
+      <path
+        fill="#4285F4"
+        d="M21.6 12.23c0-.82-.07-1.42-.22-2.05H12v3.72h5.51c-.11.92-.71 2.31-2.04 3.24l-.02.12 2.96 2.29.2.02c1.86-1.72 2.99-4.25 2.99-7.34z"
+      />
+      <path
+        fill="#34A853"
+        d="M12 22c2.66 0 4.89-.88 6.52-2.39l-3.11-2.42c-.83.58-1.95.99-3.41.99a5.93 5.93 0 0 1-5.6-4.1l-.12.01-3.08 2.39-.04.11A9.85 9.85 0 0 0 12 22z"
+      />
+      <path
+        fill="#FBBC05"
+        d="M6.4 14.08A6.17 6.17 0 0 1 6.07 12c0-.72.12-1.42.32-2.08l-.01-.13-3.12-2.42-.1.05A9.93 9.93 0 0 0 2.1 12c0 1.64.39 3.19 1.07 4.57l3.23-2.49z"
+      />
+      <path
+        fill="#EA4335"
+        d="M12 5.82c1.85 0 3.1.8 3.81 1.47l2.78-2.72C16.88 2.98 14.66 2 12 2a9.85 9.85 0 0 0-8.84 5.42l3.22 2.5A5.96 5.96 0 0 1 12 5.82z"
+      />
+    </svg>
+  );
+}

--- a/src/auth/auth-provider-button.tsx
+++ b/src/auth/auth-provider-button.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { ButtonHTMLAttributes, ReactNode } from 'react';
+import { type RenderElement, renderElement } from '../lib/render-element.js';
 import { cn } from '../lib/utils.js';
 
 export type AuthProvider = 'google' | (string & {});
@@ -14,7 +15,13 @@ export interface AuthProviderButtonProps
   loadingLabel?: ReactNode;
   lastUsed?: boolean;
   lastUsedLabel?: ReactNode;
+  render?: RenderElement<ButtonHTMLAttributes<HTMLButtonElement>>;
 }
+
+type AuthProviderButtonRenderProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  'data-provider'?: string;
+  'data-last-used'?: boolean;
+};
 
 export function AuthProviderButton({
   provider,
@@ -24,6 +31,7 @@ export function AuthProviderButton({
   loadingLabel = 'Loading...',
   lastUsed = false,
   lastUsedLabel = 'Last used',
+  render,
   disabled,
   className,
   type = 'button',
@@ -32,19 +40,8 @@ export function AuthProviderButton({
   const resolvedIcon = icon ?? (provider === 'google' ? <GoogleIcon /> : null);
   const isDisabled = disabled || loading;
 
-  return (
-    <button
-      type={type}
-      disabled={isDisabled}
-      aria-busy={loading || undefined}
-      data-provider={provider}
-      data-last-used={lastUsed || undefined}
-      className={cn(
-        'relative inline-flex min-h-11 w-full items-center justify-center gap-3 rounded-md border border-border bg-background px-4 py-2.5 text-sm font-medium text-foreground shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-60',
-        className
-      )}
-      {...props}
-    >
+  const children = (
+    <>
       {resolvedIcon && (
         <span className="flex size-5 shrink-0 items-center justify-center" aria-hidden="true">
           {resolvedIcon}
@@ -59,8 +56,28 @@ export function AuthProviderButton({
           {lastUsedLabel}
         </span>
       )}
-    </button>
+    </>
   );
+
+  const buttonProps = {
+    type,
+    disabled: isDisabled,
+    'aria-busy': loading || undefined,
+    'data-provider': provider,
+    'data-last-used': lastUsed || undefined,
+    className: cn(
+      'relative inline-flex min-h-11 w-full items-center justify-center gap-3 rounded-md border border-border bg-background px-4 py-2.5 text-sm font-medium text-foreground shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-60',
+      className
+    ),
+    ...props,
+    children,
+  } satisfies AuthProviderButtonRenderProps;
+
+  if (render) {
+    return renderElement(render, buttonProps);
+  }
+
+  return <button {...buttonProps} />;
 }
 
 function GoogleIcon() {

--- a/src/auth/auth-provider-list.tsx
+++ b/src/auth/auth-provider-list.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { Children, type HTMLAttributes, isValidElement, type ReactNode } from 'react';
+import { cn } from '../lib/utils.js';
+
+export interface AuthProviderListProps extends HTMLAttributes<HTMLUListElement> {
+  children: ReactNode;
+  label?: string;
+}
+
+export function AuthProviderList({
+  children,
+  className,
+  label = 'Authentication providers',
+  ...props
+}: AuthProviderListProps) {
+  return (
+    <ul aria-label={label} className={cn('flex w-full flex-col gap-3', className)} {...props}>
+      {Children.toArray(children).map((child, index) => (
+        <li
+          key={isValidElement(child) && child.key != null ? child.key : index}
+          className="contents"
+        >
+          {child}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/auth/better-auth.test.tsx
+++ b/src/auth/better-auth.test.tsx
@@ -61,6 +61,35 @@ describe('better-auth adapter', () => {
     expect(forwardedClick).not.toHaveBeenCalled();
   });
 
+  it('keeps internal pending state when external loading is false', async () => {
+    let resolveSocial!: (value: unknown) => void;
+    const social = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveSocial = resolve;
+        })
+    );
+
+    render(
+      <BetterAuthProviderButton
+        authClient={{ signIn: { social } }}
+        label="Continue with Google"
+        loading={false}
+      />
+    );
+
+    const button = screen.getByRole('button', { name: 'Continue with Google' });
+
+    fireEvent.click(button);
+    await waitFor(() => expect(button).toBeDisabled());
+    fireEvent.click(button);
+
+    expect(social).toHaveBeenCalledTimes(1);
+
+    resolveSocial({ ok: true });
+    await waitFor(() => expect(button).not.toBeDisabled());
+  });
+
   it('reports an error when social sign-in is unavailable', async () => {
     const onError = vi.fn();
 

--- a/src/auth/better-auth.test.tsx
+++ b/src/auth/better-auth.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   BetterAuthOneTap,
   BetterAuthProviderButton,
+  type BetterAuthProviderButtonProps,
   createBetterAuthAdapter,
   useBetterAuthLastLoginMethod,
 } from './better-auth.js';
@@ -37,6 +38,27 @@ describe('better-auth adapter', () => {
     expect(onPendingChange).toHaveBeenNthCalledWith(1, true);
     expect(onPendingChange).toHaveBeenLastCalledWith(false);
     expect(onSuccess).toHaveBeenCalledWith({ ok: true });
+  });
+
+  it('does not allow forwarded button props to replace social sign-in', async () => {
+    const social = vi.fn().mockResolvedValue({ ok: true });
+    const forwardedClick = vi.fn();
+    const forwardedProps = {
+      onClick: forwardedClick,
+    } as unknown as BetterAuthProviderButtonProps;
+
+    render(
+      <BetterAuthProviderButton
+        {...forwardedProps}
+        authClient={{ signIn: { social } }}
+        label="Continue with Google"
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue with Google' }));
+
+    await waitFor(() => expect(social).toHaveBeenCalledWith({ provider: 'google' }));
+    expect(forwardedClick).not.toHaveBeenCalled();
   });
 
   it('reports an error when social sign-in is unavailable', async () => {

--- a/src/auth/better-auth.test.tsx
+++ b/src/auth/better-auth.test.tsx
@@ -1,0 +1,133 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  BetterAuthOneTap,
+  BetterAuthProviderButton,
+  createBetterAuthAdapter,
+  useBetterAuthLastLoginMethod,
+} from './better-auth.js';
+
+describe('better-auth adapter', () => {
+  it('calls social sign-in and reports pending state', async () => {
+    const social = vi.fn().mockResolvedValue({ ok: true });
+    const onPendingChange = vi.fn();
+    const onSuccess = vi.fn();
+
+    render(
+      <BetterAuthProviderButton
+        authClient={{ signIn: { social } }}
+        provider="google"
+        callbackURL="/dashboard"
+        errorCallbackURL="/login?error=1"
+        label="Continue with Google"
+        onPendingChange={onPendingChange}
+        onSuccess={onSuccess}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue with Google' }));
+
+    await waitFor(() =>
+      expect(social).toHaveBeenCalledWith({
+        provider: 'google',
+        callbackURL: '/dashboard',
+        errorCallbackURL: '/login?error=1',
+      })
+    );
+    expect(onPendingChange).toHaveBeenNthCalledWith(1, true);
+    expect(onPendingChange).toHaveBeenLastCalledWith(false);
+    expect(onSuccess).toHaveBeenCalledWith({ ok: true });
+  });
+
+  it('reports an error when social sign-in is unavailable', async () => {
+    const onError = vi.fn();
+
+    render(
+      <BetterAuthProviderButton authClient={{}} label="Continue with Google" onError={onError} />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue with Google' }));
+
+    expect(onError).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it('reads the last used login method when the plugin is available', async () => {
+    function Probe() {
+      const method = useBetterAuthLastLoginMethod({
+        getLastUsedLoginMethod: () => Promise.resolve('google'),
+      });
+
+      return <div data-testid="method">{method ?? 'none'}</div>;
+    }
+
+    render(<Probe />);
+
+    await waitFor(() => expect(screen.getByTestId('method')).toHaveTextContent('google'));
+  });
+
+  it('returns null when last used login method is unsupported', async () => {
+    function Probe() {
+      const method = useBetterAuthLastLoginMethod({});
+
+      return <div data-testid="method">{method ?? 'none'}</div>;
+    }
+
+    render(<Probe />);
+
+    await waitFor(() => expect(screen.getByTestId('method')).toHaveTextContent('none'));
+  });
+
+  it('mounts one tap only when enabled and supported', async () => {
+    const oneTap = vi.fn().mockResolvedValue({ credential: 'ok' });
+    const onSuccess = vi.fn();
+
+    render(
+      <BetterAuthOneTap
+        authClient={{ oneTap }}
+        enabled
+        callbackURL="/dashboard"
+        onSuccess={onSuccess}
+      />
+    );
+
+    await waitFor(() => expect(oneTap).toHaveBeenCalledWith({ callbackURL: '/dashboard' }));
+    expect(onSuccess).toHaveBeenCalledWith({ credential: 'ok' });
+  });
+
+  it('does not remount one tap when inline callbacks change', async () => {
+    const oneTap = vi.fn().mockResolvedValue({ credential: 'ok' });
+    const authClient = { oneTap };
+    let successCount = 0;
+
+    function OneTapProbe({ count }: { count: number }) {
+      return (
+        <BetterAuthOneTap
+          authClient={authClient}
+          callbackURL="/dashboard"
+          onSuccess={() => {
+            successCount += count;
+          }}
+        />
+      );
+    }
+
+    const { rerender } = render(<OneTapProbe count={1} />);
+    await waitFor(() => expect(oneTap).toHaveBeenCalledTimes(1));
+
+    rerender(<OneTapProbe count={2} />);
+
+    expect(oneTap).toHaveBeenCalledTimes(1);
+    expect(successCount).toBe(1);
+  });
+
+  it('creates bound adapter helpers for a shared better-auth client', async () => {
+    const social = vi.fn().mockResolvedValue({ ok: true });
+    const adapter = createBetterAuthAdapter({ signIn: { social } });
+
+    render(<adapter.BetterAuthProviderButton label="Continue with Google" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue with Google' }));
+
+    await waitFor(() => expect(social).toHaveBeenCalledWith({ provider: 'google' }));
+  });
+});

--- a/src/auth/better-auth.tsx
+++ b/src/auth/better-auth.tsx
@@ -44,7 +44,7 @@ export function BetterAuthProviderButton({
   ...props
 }: BetterAuthProviderButtonProps) {
   const [internalPending, setInternalPending] = useState(false);
-  const pending = loading ?? internalPending;
+  const pending = Boolean(loading || internalPending);
 
   return (
     <AuthProviderButton

--- a/src/auth/better-auth.tsx
+++ b/src/auth/better-auth.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { AuthProviderButton, type AuthProviderButtonProps } from './auth-provider-button.js';
+
+export interface BetterAuthSocialArgs {
+  provider: string;
+  callbackURL?: string;
+  errorCallbackURL?: string;
+}
+
+export interface BetterAuthOneTapArgs {
+  callbackURL?: string;
+}
+
+export interface BetterAuthClientLike {
+  signIn?: {
+    social?: (args: BetterAuthSocialArgs) => Promise<unknown> | unknown;
+  };
+  oneTap?: (args: BetterAuthOneTapArgs) => Promise<unknown> | unknown;
+  getLastUsedLoginMethod?: () => Promise<string | null | undefined> | string | null | undefined;
+}
+
+export interface BetterAuthProviderButtonProps
+  extends Omit<AuthProviderButtonProps, 'onClick' | 'provider'> {
+  authClient: BetterAuthClientLike;
+  provider?: string;
+  callbackURL?: string;
+  errorCallbackURL?: string;
+  onPendingChange?: (pending: boolean) => void;
+  onError?: (error: unknown) => void;
+  onSuccess?: (result: unknown) => void;
+}
+
+export function BetterAuthProviderButton({
+  authClient,
+  provider = 'google',
+  callbackURL,
+  errorCallbackURL,
+  onPendingChange,
+  onError,
+  onSuccess,
+  loading,
+  ...props
+}: BetterAuthProviderButtonProps) {
+  const [internalPending, setInternalPending] = useState(false);
+  const pending = loading ?? internalPending;
+
+  return (
+    <AuthProviderButton
+      provider={provider}
+      loading={pending}
+      onClick={async () => {
+        const social = authClient.signIn?.social;
+        if (!social) {
+          onError?.(new Error('better-auth social sign-in is unavailable.'));
+          return;
+        }
+
+        setInternalPending(true);
+        onPendingChange?.(true);
+        try {
+          const result = await social({ provider, callbackURL, errorCallbackURL });
+          onSuccess?.(result);
+        } catch (error) {
+          onError?.(error);
+        } finally {
+          setInternalPending(false);
+          onPendingChange?.(false);
+        }
+      }}
+      {...props}
+    />
+  );
+}
+
+export function useBetterAuthLastLoginMethod(authClient: BetterAuthClientLike) {
+  const [method, setMethod] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+
+    async function loadLastMethod() {
+      try {
+        const getter = authClient.getLastUsedLoginMethod;
+        const nextMethod = getter ? await getter() : null;
+        if (active) {
+          setMethod(nextMethod ?? null);
+        }
+      } catch {
+        if (active) {
+          setMethod(null);
+        }
+      }
+    }
+
+    void loadLastMethod();
+
+    return () => {
+      active = false;
+    };
+  }, [authClient]);
+
+  return method;
+}
+
+export interface BetterAuthOneTapProps {
+  authClient: BetterAuthClientLike;
+  enabled?: boolean;
+  callbackURL?: string;
+  onError?: (error: unknown) => void;
+  onSuccess?: (result: unknown) => void;
+}
+
+export function BetterAuthOneTap({
+  authClient,
+  enabled = true,
+  callbackURL,
+  onError,
+  onSuccess,
+}: BetterAuthOneTapProps) {
+  const onErrorRef = useRef(onError);
+  const onSuccessRef = useRef(onSuccess);
+
+  useEffect(() => {
+    onErrorRef.current = onError;
+    onSuccessRef.current = onSuccess;
+  }, [onError, onSuccess]);
+
+  useEffect(() => {
+    if (!enabled || !authClient.oneTap) {
+      return;
+    }
+
+    let active = true;
+
+    async function mountOneTap() {
+      try {
+        const result = await authClient.oneTap?.({ callbackURL });
+        if (active) {
+          onSuccessRef.current?.(result);
+        }
+      } catch (error) {
+        if (active) {
+          onErrorRef.current?.(error);
+        }
+      }
+    }
+
+    void mountOneTap();
+
+    return () => {
+      active = false;
+    };
+  }, [authClient, callbackURL, enabled]);
+
+  return null;
+}
+
+export function createBetterAuthAdapter(authClient: BetterAuthClientLike) {
+  return {
+    BetterAuthProviderButton: (props: Omit<BetterAuthProviderButtonProps, 'authClient'>) => (
+      <BetterAuthProviderButton authClient={authClient} {...props} />
+    ),
+    BetterAuthOneTap: (props: Omit<BetterAuthOneTapProps, 'authClient'>) => (
+      <BetterAuthOneTap authClient={authClient} {...props} />
+    ),
+    useBetterAuthLastLoginMethod: () => useBetterAuthLastLoginMethod(authClient),
+  };
+}

--- a/src/auth/better-auth.tsx
+++ b/src/auth/better-auth.tsx
@@ -48,6 +48,7 @@ export function BetterAuthProviderButton({
 
   return (
     <AuthProviderButton
+      {...props}
       provider={provider}
       loading={pending}
       onClick={async () => {
@@ -69,7 +70,6 @@ export function BetterAuthProviderButton({
           onPendingChange?.(false);
         }
       }}
-      {...props}
     />
   );
 }

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,0 +1,6 @@
+export type { AuthMessageProps, AuthOneTapSlotProps } from './auth-message.js';
+export { AuthError, AuthNotice, AuthOneTapSlot } from './auth-message.js';
+export type { AuthProvider, AuthProviderButtonProps } from './auth-provider-button.js';
+export { AuthProviderButton } from './auth-provider-button.js';
+export type { AuthProviderListProps } from './auth-provider-list.js';
+export { AuthProviderList } from './auth-provider-list.js';

--- a/src/auth/public.ts
+++ b/src/auth/public.ts
@@ -1,0 +1,6 @@
+export type { AuthMessageProps, AuthOneTapSlotProps } from './auth-message.js';
+export { AuthError, AuthNotice, AuthOneTapSlot } from './auth-message.js';
+export type { AuthProvider, AuthProviderButtonProps } from './auth-provider-button.js';
+export { AuthProviderButton } from './auth-provider-button.js';
+export type { AuthProviderListProps } from './auth-provider-list.js';
+export { AuthProviderList } from './auth-provider-list.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,5 @@ export * from './chat/public.js';
 export * from './marketing/public.js';
 export * from './panel/public.js';
 export * from './shell/index.js'; // v2 surface
+export * from './theme/index.js';
 export * from './timeline/public.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export * from './auth/public.js';
 export * from './brand/public.js';
 export * from './chat/public.js';
 export * from './marketing/public.js';

--- a/src/lib/render-element.tsx
+++ b/src/lib/render-element.tsx
@@ -1,0 +1,50 @@
+import {
+  cloneElement,
+  isValidElement,
+  type KeyboardEventHandler,
+  type MouseEventHandler,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
+import { cn } from './utils.js';
+
+export type RenderElement<TProps extends { className?: string; children?: ReactNode }> =
+  ReactElement<Partial<TProps>>;
+
+type EventProps = {
+  onClick?: MouseEventHandler<HTMLElement>;
+  onKeyDown?: KeyboardEventHandler<HTMLElement>;
+};
+
+function composeEventHandlers<Event extends { defaultPrevented: boolean }>(
+  consumerHandler: ((event: Event) => void) | undefined,
+  medaHandler: ((event: Event) => void) | undefined
+) {
+  if (!consumerHandler) return medaHandler;
+  if (!medaHandler) return consumerHandler;
+
+  return (event: Event) => {
+    consumerHandler(event);
+    if (!event.defaultPrevented) {
+      medaHandler(event);
+    }
+  };
+}
+
+export function renderElement<TProps extends { className?: string; children?: ReactNode }>(
+  render: RenderElement<TProps>,
+  props: TProps
+): ReactNode {
+  if (!isValidElement(render)) return null;
+
+  const renderProps = render.props as Partial<TProps> & EventProps;
+  const medaProps = props as TProps & EventProps;
+
+  return cloneElement(render, {
+    ...renderProps,
+    ...medaProps,
+    className: cn(renderProps.className, medaProps.className),
+    onClick: composeEventHandlers(renderProps.onClick, medaProps.onClick),
+    onKeyDown: composeEventHandlers(renderProps.onKeyDown, medaProps.onKeyDown),
+  } as Partial<TProps>);
+}

--- a/src/recipes/next.test.ts
+++ b/src/recipes/next.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { nextAppShellRecipe, nextRecipes } from './next.js';
+
+describe('Next recipes', () => {
+  it('publishes copyable Next AppShell recipe metadata', () => {
+    expect(nextRecipes).toContain(nextAppShellRecipe);
+    expect(nextAppShellRecipe.name).toBe('meda-next-app-shell');
+    expect(nextAppShellRecipe.dependencies).toContain('@medalsocial/meda');
+    expect(nextAppShellRecipe.peerDependencies).toEqual(
+      expect.arrayContaining(['next', 'react', 'react-dom'])
+    );
+    expect(nextAppShellRecipe.files[0]?.content).toContain('next/link');
+  });
+
+  it('passes route panel views to AppShell on first render', () => {
+    expect(nextAppShellRecipe.files[0]?.content).toContain(
+      'rightPanel={{ panelViews, defaultView: defaultPanelView }}'
+    );
+    expect(nextAppShellRecipe.files[0]?.content).not.toContain('panelViews: []');
+  });
+
+  it('documents accessibility and composition contracts', () => {
+    expect(nextAppShellRecipe.accessibility).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('linkProps'),
+        expect.stringContaining('Auth provider buttons'),
+      ])
+    );
+  });
+});

--- a/src/recipes/next.test.ts
+++ b/src/recipes/next.test.ts
@@ -20,10 +20,24 @@ describe('Next recipes', () => {
   });
 
   it('documents accessibility and composition contracts', () => {
+    expect(nextAppShellRecipe.accessibility.length).toBeGreaterThan(0);
+    expect(nextAppShellRecipe.composition.length).toBeGreaterThan(0);
     expect(nextAppShellRecipe.accessibility).toEqual(
       expect.arrayContaining([
         expect.stringContaining('linkProps'),
+        expect.stringContaining('aria-current'),
         expect.stringContaining('Auth provider buttons'),
+        expect.stringContaining('headings'),
+        expect.stringContaining('Reduced-motion'),
+      ])
+    );
+    expect(nextAppShellRecipe.composition).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('MedaShellProvider'),
+        expect.stringContaining('AppShell'),
+        expect.stringContaining('rightPanel'),
+        expect.stringContaining('PanelViewsProvider'),
+        expect.stringContaining('renderLink'),
       ])
     );
   });

--- a/src/recipes/next.ts
+++ b/src/recipes/next.ts
@@ -1,0 +1,142 @@
+export interface MedaRecipeFile {
+  path: string;
+  target: string;
+  type: 'registry:block' | 'registry:component' | 'registry:hook' | 'registry:lib';
+  content: string;
+}
+
+export interface MedaRecipe {
+  name: string;
+  title: string;
+  description: string;
+  dependencies: string[];
+  peerDependencies: string[];
+  cssVars: string[];
+  files: MedaRecipeFile[];
+  accessibility: string[];
+}
+
+export const nextAppShellRecipe = {
+  name: 'meda-next-app-shell',
+  title: 'Meda Next AppShell',
+  description:
+    'Copyable Next.js App Router shell adapter with next/link routing, route-owned panel views, and auth controls.',
+  dependencies: ['@medalsocial/meda', 'lucide-react'],
+  peerDependencies: ['next', 'react', 'react-dom'],
+  cssVars: ['@medalsocial/meda/styles.css'],
+  files: [
+    {
+      path: 'registry/meda/meda-next-app-shell/meda-next-app-shell.tsx',
+      target: 'components/meda/meda-next-app-shell.tsx',
+      type: 'registry:block',
+      content: `\
+'use client'
+
+import Link from 'next/link'
+import type { ComponentProps, ReactNode } from 'react'
+import {
+  AppShell,
+  AuthError,
+  AuthNotice,
+  AuthOneTapSlot,
+  AuthProviderButton,
+  AuthProviderList,
+  MedaShellProvider,
+  PanelViewsProvider,
+  type AppDefinition,
+  type IconRailItem,
+  type PanelView,
+  type WorkspaceDefinition,
+} from '@medalsocial/meda/shell'
+
+export function MedaNextWorkspaceShell({
+  workspace,
+  apps,
+  iconItems,
+  activeIconId,
+  panelViews = [],
+  defaultPanelView,
+  children,
+}: {
+  workspace: WorkspaceDefinition
+  apps: AppDefinition[]
+  iconItems: IconRailItem[]
+  activeIconId?: string
+  panelViews?: PanelView[]
+  defaultPanelView?: string
+  children: ReactNode
+}) {
+  return (
+    <MedaShellProvider workspace={workspace} apps={apps}>
+      <AppShell
+        variant="workspace"
+        iconRail={{
+          mainItems: iconItems,
+          activeId: activeIconId,
+          renderLink: ({ item, linkProps }) => (
+            <Link {...linkProps} href={item.to} prefetch />
+          ),
+        }}
+        rightPanel={{ panelViews, defaultView: defaultPanelView }}
+      >
+        <PanelViewsProvider views={panelViews} defaultView={defaultPanelView}>
+          {children}
+        </PanelViewsProvider>
+      </AppShell>
+    </MedaShellProvider>
+  )
+}
+
+export function MedaNextAuthShell({
+  brandName,
+  brandMark,
+  appName,
+  tagline,
+  preview,
+  error,
+  notice,
+  onGoogleSignIn,
+}: {
+  brandName: ReactNode
+  brandMark?: ReactNode
+  appName?: ReactNode
+  tagline?: ReactNode
+  preview?: ReactNode
+  error?: ReactNode
+  notice?: ReactNode
+  onGoogleSignIn: ComponentProps<typeof AuthProviderButton>['onClick']
+}) {
+  return (
+    <MedaShellProvider workspace={{ id: 'auth', name: 'Auth', icon: brandMark }} apps={[]}>
+      <AppShell
+        variant="auth"
+        branding={{ brandName, brandMark, appName, tagline }}
+        preview={preview}
+      >
+        <AuthProviderList>
+          <AuthProviderButton
+            provider="google"
+            label="Continue with Google"
+            onClick={onGoogleSignIn}
+          />
+        </AuthProviderList>
+        <AuthNotice>{notice}</AuthNotice>
+        <AuthError>{error}</AuthError>
+        <AuthOneTapSlot />
+      </AppShell>
+    </MedaShellProvider>
+  )
+}
+`,
+    },
+  ],
+  accessibility: [
+    'Every drawer and panel keeps its accessible name from AppShell and RightPanel.',
+    'Custom link renderers must forward all linkProps to preserve aria-current, labels, handlers, and className.',
+    'Auth provider buttons keep the visible provider affordance separate from the accessible button name.',
+    'Route-owned panel views should expose headings inside their rendered panel content.',
+    'Reduced-motion behavior remains delegated to Meda shell motion tokens.',
+  ],
+} satisfies MedaRecipe;
+
+export const nextRecipes = [nextAppShellRecipe] satisfies MedaRecipe[];

--- a/src/recipes/next.ts
+++ b/src/recipes/next.ts
@@ -14,6 +14,7 @@ export interface MedaRecipe {
   cssVars: string[];
   files: MedaRecipeFile[];
   accessibility: string[];
+  composition: string[];
 }
 
 export const nextAppShellRecipe = {
@@ -136,6 +137,12 @@ export function MedaNextAuthShell({
     'Auth provider buttons keep the visible provider affordance separate from the accessible button name.',
     'Route-owned panel views should expose headings inside their rendered panel content.',
     'Reduced-motion behavior remains delegated to Meda shell motion tokens.',
+  ],
+  composition: [
+    'MedaShellProvider owns workspace and app context for the copied shell adapter.',
+    'AppShell receives route-owned rightPanel views on first render to avoid delayed panel UI.',
+    'PanelViewsProvider wraps children with the same panelViews and defaultPanelView for nested route registrations.',
+    'renderLink composes Next Link by forwarding Meda linkProps before setting framework-specific props.',
   ],
 } satisfies MedaRecipe;
 

--- a/src/shell/app-shell-variants.test.tsx
+++ b/src/shell/app-shell-variants.test.tsx
@@ -29,6 +29,49 @@ describe('AppShell variant', () => {
     expect(screen.getByLabelText('email')).toBeInTheDocument();
   });
 
+  it('renders the auth variant with branding shorthand', () => {
+    render(
+      baseProvider(
+        <AppShell
+          variant="auth"
+          branding={{
+            brandName: 'Housebets',
+            brandMark: <span data-testid="brand-mark">HB</span>,
+            appName: 'Auto',
+            tagline: 'by Housebets',
+          }}
+          preview={<div data-testid="auth-preview">Preview</div>}
+        >
+          <input aria-label="email" />
+        </AppShell>
+      )
+    );
+
+    expect(screen.getByRole('heading', { name: 'Auto' })).toBeInTheDocument();
+    expect(screen.getByText('by Housebets')).toBeInTheDocument();
+    expect(screen.getAllByTestId('brand-mark')).toHaveLength(2);
+    expect(screen.getByTestId('auth-preview')).toBeInTheDocument();
+    expect(screen.getByLabelText('email')).toBeInTheDocument();
+  });
+
+  it('lets auth config override branding shorthand fields', () => {
+    render(
+      baseProvider(
+        <AppShell
+          variant="auth"
+          auth={{ title: 'Admin sign in', brandName: 'Meda Admin' }}
+          branding={{ brandName: 'Housebets', appName: 'Auto' }}
+        >
+          <input aria-label="email" />
+        </AppShell>
+      )
+    );
+
+    expect(screen.getByRole('heading', { name: 'Admin sign in' })).toBeInTheDocument();
+    expect(screen.getByText('Meda Admin')).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Auto' })).not.toBeInTheDocument();
+  });
+
   it('renders the workspace variant when variant="workspace"', () => {
     render(
       baseProvider(

--- a/src/shell/app-shell-workspace.test.tsx
+++ b/src/shell/app-shell-workspace.test.tsx
@@ -252,6 +252,35 @@ describe('AppShellWorkspace', () => {
     expect(screen.getByTestId('mobile-drawer-state')).toHaveTextContent('closed');
   });
 
+  it('keeps mobile menu linkProps safe to spread without embedding close handler', () => {
+    (useShellViewport as ReturnType<typeof vi.fn>).mockReturnValue('mobile');
+    let linkPropsOnClick: unknown = null;
+
+    render(
+      <Provider>
+        <MobileDrawerStateProbe />
+        <AppShellWorkspace
+          iconRail={{
+            activeId: 'i',
+            mainItems: [{ id: 'i', label: 'Inbox', to: '/i', icon: Inbox }],
+            renderLink: ({ item, linkProps }) => {
+              linkPropsOnClick = linkProps.onClick;
+              return <a {...linkProps} data-testid={`spread-mobile-link-${item.id}`} />;
+            },
+          }}
+        >
+          <main aria-label="content">hi</main>
+        </AppShellWorkspace>
+      </Provider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Menu' }));
+    expect(linkPropsOnClick).toBeUndefined();
+
+    fireEvent.click(screen.getByTestId('spread-mobile-link-i'));
+    expect(screen.getByTestId('mobile-drawer-state')).toHaveTextContent('closed');
+  });
+
   it('renders mobile context module custom content with the context rail app id', () => {
     (useShellViewport as ReturnType<typeof vi.fn>).mockReturnValue('mobile');
 

--- a/src/shell/app-shell.tsx
+++ b/src/shell/app-shell.tsx
@@ -7,6 +7,7 @@ import { AppShellChat } from './app-shell-chat.js';
 import { AppShellWorkspace } from './app-shell-workspace.js';
 import { useMedaShell } from './shell-provider.js';
 import type {
+  AppShellAuthBranding,
   AppShellAuthConfig,
   AppShellContextRailConfig,
   AppShellIconRailConfig,
@@ -22,7 +23,10 @@ export type AppShellProps = AppShellBaseProps &
   (
     | {
         variant: 'auth';
-        auth: AppShellAuthConfig;
+        auth?: AppShellAuthConfig;
+        branding?: AppShellAuthBranding;
+        preview?: ReactNode;
+        actions?: ReactNode;
       }
     | {
         variant: 'workspace';
@@ -58,7 +62,7 @@ export function AppShell(props: AppShellProps) {
 
   switch (props.variant) {
     case 'auth':
-      return wrapper(<AppShellAuth {...props.auth}>{props.children}</AppShellAuth>);
+      return wrapper(<AppShellAuth {...resolveAuthConfig(props)}>{props.children}</AppShellAuth>);
     case 'workspace':
       return wrapper(
         <AppShellWorkspace
@@ -75,6 +79,20 @@ export function AppShell(props: AppShellProps) {
         <AppShellChat globalActions={props.globalActions}>{props.children}</AppShellChat>
       );
   }
+}
+
+function resolveAuthConfig(props: Extract<AppShellProps, { variant: 'auth' }>): AppShellAuthConfig {
+  const { auth, branding } = props;
+
+  return {
+    title: auth?.title ?? branding?.appName ?? branding?.brandName ?? 'Sign in',
+    description: auth?.description ?? branding?.tagline,
+    brandName: auth?.brandName ?? branding?.brandName,
+    brandMark: auth?.brandMark ?? branding?.brandMark,
+    eyebrow: auth?.eyebrow,
+    preview: auth?.preview ?? props.preview,
+    actions: auth?.actions ?? props.actions,
+  };
 }
 
 export function AppShellBody({ children, className }: { children: ReactNode; className?: string }) {

--- a/src/shell/context-rail.test.tsx
+++ b/src/shell/context-rail.test.tsx
@@ -363,6 +363,26 @@ describe('ContextRail — module items rendering', () => {
     expect(screen.queryAllByRole('link')).toHaveLength(0);
   });
 
+  it('renderLink receives default link props for route adapters', () => {
+    render(
+      <Wrapper>
+        <ContextRail
+          appId="mail"
+          module={MODULE}
+          activeItemId="inbox"
+          renderLink={({ item, linkProps }) => (
+            <a {...linkProps} data-testid={`route-link-${item.id}`} data-route-link="true" />
+          )}
+        />
+      </Wrapper>
+    );
+
+    const inboxLink = screen.getByTestId('route-link-inbox');
+    expect(inboxLink).toHaveAttribute('href', '/inbox');
+    expect(inboxLink).toHaveAttribute('aria-current', 'page');
+    expect(inboxLink).toHaveAttribute('data-route-link', 'true');
+  });
+
   it('item with shortcut renders keyboard shortcut text', () => {
     const moduleWithShortcut: ContextModule = {
       id: 'mail',

--- a/src/shell/context-rail.tsx
+++ b/src/shell/context-rail.tsx
@@ -16,8 +16,8 @@
  */
 
 import { PanelLeftClose, PanelLeftOpen } from 'lucide-react';
-import type { ReactNode, PointerEvent as ReactPointerEvent } from 'react';
-import { useId, useRef, useState } from 'react';
+import type { AnchorHTMLAttributes, ReactNode, PointerEvent as ReactPointerEvent } from 'react';
+import { Fragment, useId, useRef, useState } from 'react';
 import { cn } from '../lib/utils.js';
 import { useMedaShell } from './shell-provider.js';
 import type { ContextModule, ShellLinkRenderArgs } from './types.js';
@@ -269,19 +269,21 @@ export function ContextRail({
                 </>
               );
 
+              const linkProps = {
+                href: item.to,
+                'aria-current': isActive ? 'page' : undefined,
+                className: klass,
+                children: inner,
+              } satisfies AnchorHTMLAttributes<HTMLAnchorElement>;
+
               if (renderLink) {
-                return renderLink({ item, isActive, className: klass, children: inner });
+                return (
+                  <Fragment key={item.id}>
+                    {renderLink({ item, isActive, className: klass, children: inner, linkProps })}
+                  </Fragment>
+                );
               }
-              return (
-                <a
-                  key={item.id}
-                  href={item.to}
-                  aria-current={isActive ? 'page' : undefined}
-                  className={klass}
-                >
-                  {inner}
-                </a>
-              );
+              return <a key={item.id} {...linkProps} />;
             })}
           </nav>
         )}

--- a/src/shell/icon-rail.test.tsx
+++ b/src/shell/icon-rail.test.tsx
@@ -155,6 +155,26 @@ describe('IconRail', () => {
     expect(screen.getByTestId('link-settings')).toBeInTheDocument();
   });
 
+  it('renderLink receives default link props for router adapters', () => {
+    render(
+      <Wrapper>
+        <IconRail
+          mainItems={mainItems}
+          activeId="inbox"
+          renderLink={({ item, linkProps }) => (
+            <a {...linkProps} data-testid={`router-link-${item.id}`} data-router-link="true" />
+          )}
+        />
+      </Wrapper>
+    );
+
+    const inboxLink = screen.getByTestId('router-link-inbox');
+    expect(inboxLink).toHaveAttribute('href', '/inbox');
+    expect(inboxLink).toHaveAttribute('aria-label', 'Inbox');
+    expect(inboxLink).toHaveAttribute('aria-current', 'page');
+    expect(inboxLink).toHaveAttribute('data-router-link', 'true');
+  });
+
   it('utilityItems render below mainItems with divider between', () => {
     render(
       <Wrapper>

--- a/src/shell/icon-rail.tsx
+++ b/src/shell/icon-rail.tsx
@@ -2,7 +2,7 @@
 
 import type { LucideIcon } from 'lucide-react';
 import { ChevronDown, ChevronUp } from 'lucide-react';
-import type { ReactNode } from 'react';
+import type { AnchorHTMLAttributes, ReactNode } from 'react';
 import { useState } from 'react';
 import {
   Tooltip,
@@ -30,6 +30,7 @@ export interface IconRailRenderLinkArgs {
   isActive: boolean;
   className: string;
   children: ReactNode;
+  linkProps: AnchorHTMLAttributes<HTMLAnchorElement>;
 }
 
 export interface IconRailProps {
@@ -114,18 +115,19 @@ export function IconRail({
       </>
     );
 
+    const linkProps = {
+      href: item.to,
+      'aria-label': item.label,
+      'aria-current': isActive ? 'page' : undefined,
+      className: 'contents',
+      children: inner,
+    } satisfies AnchorHTMLAttributes<HTMLAnchorElement>;
+
     const linkContent = renderLink ? (
       // renderLink consumers receive the className so they can apply it themselves
-      renderLink({ item, isActive, className: klass, children: inner })
+      renderLink({ item, isActive, className: klass, children: inner, linkProps })
     ) : (
-      <a
-        href={item.to}
-        aria-label={item.label}
-        aria-current={isActive ? 'page' : undefined}
-        className="contents"
-      >
-        {inner}
-      </a>
+      <a {...linkProps} />
     );
 
     return (

--- a/src/shell/index.ts
+++ b/src/shell/index.ts
@@ -4,6 +4,20 @@
 // file carries its own 'use client' — Next traces through the barrel and
 // applies them per-component. The barrel itself is just a re-exporter.
 
+export type {
+  AuthMessageProps,
+  AuthOneTapSlotProps,
+  AuthProvider,
+  AuthProviderButtonProps,
+  AuthProviderListProps,
+} from '../auth/index.js';
+export {
+  AuthError,
+  AuthNotice,
+  AuthOneTapSlot,
+  AuthProviderButton,
+  AuthProviderList,
+} from '../auth/index.js';
 // Layout
 export { AppShell, AppShellBody } from './app-shell.js';
 export type { CommandGroupDefinition } from './command-palette.js';
@@ -43,6 +57,7 @@ export { NextThemesAdapter } from './theme-next-themes.js';
 // Types
 export type {
   AppDefinition,
+  AppShellAuthBranding,
   AppShellAuthConfig,
   AppShellContextRailConfig,
   AppShellIconRailConfig,

--- a/src/shell/index.ts
+++ b/src/shell/index.ts
@@ -30,6 +30,7 @@ export { DragModeBanner } from './drag-mode-banner.js';
 // Extras (legacy components ported during Phase 15 — opt-in for apps that need them)
 export * as Extras from './extras/index.js';
 // Rails + main + panel
+export type { IconRailItem, IconRailProps, IconRailRenderLinkArgs } from './icon-rail.js';
 export { IconRail, RailDivider } from './icon-rail.js';
 export type { ShellStorageAdapter } from './layout-state.js';
 // Storage adapter (consumers may want to provide their own)

--- a/src/shell/internal/mobile-drawers.tsx
+++ b/src/shell/internal/mobile-drawers.tsx
@@ -167,24 +167,27 @@ function MenuDrawerItem({
       <span>{item.label}</span>
     </>
   );
+  const className = cn(menuItemClassName, isActive && 'bg-accent text-foreground');
+  const linkProps = {
+    href: item.to,
+    className,
+    children,
+  };
 
   if (renderLink) {
     return closeAfterLinkClick(
       renderLink({
         item,
         isActive,
-        className: cn(menuItemClassName, isActive && 'bg-accent text-foreground'),
+        className,
         children,
+        linkProps,
       }),
       onClose
     );
   }
 
-  return (
-    <a href={item.to} onClick={onClose} className={menuItemClassName}>
-      {children}
-    </a>
-  );
+  return closeAfterLinkClick(<a {...linkProps} />, onClose);
 }
 
 type MenuLinkElementProps = {

--- a/src/shell/primitives.ts
+++ b/src/shell/primitives.ts
@@ -1,0 +1,25 @@
+// State and layout primitives for consumers that want Meda shell behavior
+// without importing the full styled shell barrel.
+
+export type { ShellStorageAdapter } from './layout-state.js';
+export { createLocalStorageAdapter } from './layout-state.js';
+export type { PanelViewsProviderProps } from './panel-views-provider.js';
+export { PanelViewsProvider } from './panel-views-provider.js';
+export { ResizableHandle, ResizableShell, ResizableShellPanel } from './resizable-shell.js';
+export type { MedaShellProviderProps } from './shell-provider.js';
+export { MedaShellProvider, useMedaShell, useShellSelection } from './shell-provider.js';
+export type {
+  AppDefinition,
+  CommandDefinition,
+  ContextItem,
+  ContextModule,
+  MobileBottomNavItem,
+  PanelMode,
+  PanelView,
+  ShellLinkRenderArgs,
+  ShellRenderContext,
+  ShellViewport,
+  ThemeAdapter,
+  WorkspaceDefinition,
+} from './types.js';
+export { useShellViewport } from './use-shell-viewport.js';

--- a/src/shell/right-panel.test.tsx
+++ b/src/shell/right-panel.test.tsx
@@ -298,6 +298,27 @@ describe('RightPanel — panelViews', () => {
     expect(inspectorTab).toHaveAttribute('aria-current', 'true');
   });
 
+  it('passes tab props into custom rendered panel tabs', () => {
+    render(
+      <Wrapper mode="panel" activeView="inspector">
+        <RightPanel
+          panelViews={VIEWS}
+          renderTab={({ view, buttonProps }) => (
+            <button {...buttonProps} type="button" data-testid={`panel-tab-${view.id}`} />
+          )}
+        />
+      </Wrapper>
+    );
+
+    const inspectorTab = screen.getByTestId('panel-tab-inspector');
+    expect(inspectorTab).toHaveAccessibleName('Inspector');
+    expect(inspectorTab).toHaveAttribute('aria-current', 'true');
+    expect(inspectorTab).toHaveAttribute('data-active', 'true');
+
+    fireEvent.click(screen.getByTestId('panel-tab-activity'));
+    expect(screen.getByTestId('panel-tab-activity')).toHaveAttribute('aria-current', 'true');
+  });
+
   it('inactive tab does not have aria-current', () => {
     render(
       <Wrapper mode="panel" activeView="inspector">

--- a/src/shell/right-panel.tsx
+++ b/src/shell/right-panel.tsx
@@ -17,7 +17,8 @@
  */
 
 import { Maximize2, Minimize2, X } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+import { Fragment, useEffect, useRef, useState } from 'react';
 import { cn } from '../lib/utils.js';
 import { useResolvedPanelViews } from './panel-views-provider.js';
 import { useMedaShell } from './shell-provider.js';
@@ -47,8 +48,20 @@ export interface RightPanelProps {
    * If only ['panel'], the cycle button is hidden.
    */
   modes?: PanelMode[];
+  renderTab?: (args: RightPanelTabRenderArgs) => ReactNode;
   className?: string;
 }
+
+export interface RightPanelTabRenderArgs {
+  view: PanelView;
+  isActive: boolean;
+  buttonProps: RightPanelTabButtonProps;
+  children: ReactNode;
+}
+
+export type RightPanelTabButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  'data-active'?: boolean;
+};
 
 // ---------------------------------------------------------------------------
 // ResizeHandle — left-edge drag handle (Pattern B)
@@ -121,6 +134,7 @@ export function RightPanel({
   panelViews = EMPTY_PANEL_VIEWS,
   defaultView,
   modes = ['panel', 'expanded', 'fullscreen'],
+  renderTab,
   className,
 }: RightPanelProps) {
   const band = useShellViewport();
@@ -225,23 +239,35 @@ export function RightPanel({
               {resolvedPanelViews.map((view) => {
                 const isActive = view.id === activeView;
                 const Icon = view.icon;
-                return (
-                  <button
-                    key={view.id}
-                    type="button"
-                    aria-current={isActive ? 'true' : undefined}
-                    onClick={() => setActiveView(view.id)}
-                    className={cn(
-                      'inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium transition-colors',
-                      isActive
-                        ? 'bg-accent text-accent-foreground'
-                        : 'text-muted-foreground hover:bg-accent hover:text-foreground'
-                    )}
-                  >
+                const children = (
+                  <>
                     <Icon size={14} aria-hidden="true" />
                     <span>{view.label}</span>
-                  </button>
+                  </>
                 );
+                const buttonProps = {
+                  type: 'button',
+                  'aria-current': isActive ? 'true' : undefined,
+                  'data-active': isActive || undefined,
+                  onClick: () => setActiveView(view.id),
+                  className: cn(
+                    'inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium transition-colors',
+                    isActive
+                      ? 'bg-accent text-accent-foreground'
+                      : 'text-muted-foreground hover:bg-accent hover:text-foreground'
+                  ),
+                  children,
+                } satisfies RightPanelTabButtonProps;
+
+                if (renderTab) {
+                  return (
+                    <Fragment key={view.id}>
+                      {renderTab({ view, isActive, buttonProps, children })}
+                    </Fragment>
+                  );
+                }
+
+                return <button key={view.id} {...buttonProps} />;
               })}
             </div>
 

--- a/src/shell/types.ts
+++ b/src/shell/types.ts
@@ -1,6 +1,6 @@
 'use client';
 import type { LucideIcon } from 'lucide-react';
-import type { ReactNode } from 'react';
+import type { AnchorHTMLAttributes, ReactNode } from 'react';
 
 export interface AppDefinition {
   id: string;
@@ -64,6 +64,7 @@ export interface ShellLinkRenderArgs {
   isActive: boolean;
   className: string;
   children: ReactNode;
+  linkProps: AnchorHTMLAttributes<HTMLAnchorElement>;
 }
 
 export interface CommandDefinition {

--- a/src/shell/types.ts
+++ b/src/shell/types.ts
@@ -123,3 +123,10 @@ export interface AppShellAuthConfig {
   preview?: ReactNode;
   actions?: ReactNode;
 }
+
+export interface AppShellAuthBranding {
+  brandName?: ReactNode;
+  brandMark?: ReactNode;
+  appName?: ReactNode;
+  tagline?: ReactNode;
+}

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,0 +1,9 @@
+export {
+  createMedaThemeCss,
+  defineMedaTheme,
+  type MedaThemeConfig,
+  type MedaThemeDefinition,
+  type MedaThemeMode,
+  type MedaThemeModeConfig,
+  type MedaThemeTokenMap,
+} from './theme-bridge.js';

--- a/src/theme/theme-bridge.test.ts
+++ b/src/theme/theme-bridge.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { createMedaThemeCss, defineMedaTheme } from './theme-bridge.js';
+
+describe('Meda theme bridge', () => {
+  it('generates light and dark app-scoped token CSS', () => {
+    const theme = defineMedaTheme({
+      appId: 'auto',
+      colors: {
+        primary: 'var(--hb-brand-500)',
+      },
+      fonts: {
+        body: 'var(--font-body)',
+      },
+      light: {
+        colors: {
+          background: 'var(--hb-base-50)',
+          foreground: 'var(--hb-base-950)',
+        },
+      },
+      dark: {
+        colors: {
+          background: 'var(--hb-base-900)',
+          foreground: 'var(--hb-base-50)',
+        },
+      },
+    });
+
+    expect(createMedaThemeCss(theme)).toMatchInlineSnapshot(`
+      "[data-meda-app="auto"] {
+        --background: var(--hb-base-50);
+        --font-body: var(--font-body);
+        --foreground: var(--hb-base-950);
+        --primary: var(--hb-brand-500);
+      }
+
+      [data-meda-app="auto"].dark, [data-meda-app="auto"][data-theme="dark"] {
+        --background: var(--hb-base-900);
+        --font-body: var(--font-body);
+        --foreground: var(--hb-base-50);
+        --primary: var(--hb-brand-500);
+      }"
+    `);
+  });
+
+  it('rejects app ids that cannot be safely embedded in selectors', () => {
+    expect(() => defineMedaTheme({ appId: 'auto app' })).toThrow(
+      'Meda theme appId must contain only letters, numbers, underscores, or dashes.'
+    );
+  });
+});

--- a/src/theme/theme-bridge.ts
+++ b/src/theme/theme-bridge.ts
@@ -1,0 +1,89 @@
+export type MedaThemeMode = 'light' | 'dark';
+
+export type MedaThemeTokenMap = Record<string, string | undefined>;
+
+export interface MedaThemeModeConfig {
+  colors?: MedaThemeTokenMap;
+  fonts?: MedaThemeTokenMap;
+  tokens?: MedaThemeTokenMap;
+}
+
+export interface MedaThemeConfig extends MedaThemeModeConfig {
+  appId: string;
+  selector?: string;
+  light?: MedaThemeModeConfig;
+  dark?: MedaThemeModeConfig;
+}
+
+export interface MedaThemeDefinition {
+  appId: string;
+  selector: string;
+  light: Required<MedaThemeModeConfig>;
+  dark: Required<MedaThemeModeConfig>;
+}
+
+const MODE_KEYS = ['colors', 'fonts', 'tokens'] as const;
+
+function assertAppId(appId: string) {
+  if (!/^[a-zA-Z0-9_-]+$/.test(appId)) {
+    throw new Error('Meda theme appId must contain only letters, numbers, underscores, or dashes.');
+  }
+}
+
+function toCssVariableName(group: (typeof MODE_KEYS)[number], key: string) {
+  const normalized = key.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`);
+  if (normalized.startsWith('--')) {
+    return normalized;
+  }
+  if (group === 'fonts') {
+    return `--font-${normalized}`;
+  }
+  return `--${normalized}`;
+}
+
+function mergeModeConfig(base: MedaThemeModeConfig, mode: MedaThemeModeConfig = {}) {
+  return {
+    colors: { ...base.colors, ...mode.colors },
+    fonts: { ...base.fonts, ...mode.fonts },
+    tokens: { ...base.tokens, ...mode.tokens },
+  };
+}
+
+export function defineMedaTheme(config: MedaThemeConfig): MedaThemeDefinition {
+  assertAppId(config.appId);
+  const base = {
+    colors: config.colors ?? {},
+    fonts: config.fonts ?? {},
+    tokens: config.tokens ?? {},
+  };
+
+  return {
+    appId: config.appId,
+    selector: config.selector ?? `[data-meda-app="${config.appId}"]`,
+    light: mergeModeConfig(base, config.light),
+    dark: mergeModeConfig(base, config.dark),
+  };
+}
+
+function entriesForMode(mode: Required<MedaThemeModeConfig>) {
+  return MODE_KEYS.flatMap((group) =>
+    Object.entries(mode[group])
+      .filter((entry): entry is [string, string] => typeof entry[1] === 'string')
+      .map(([key, value]) => [toCssVariableName(group, key), value] as const)
+  ).sort(([left], [right]) => left.localeCompare(right));
+}
+
+function renderBlock(selector: string, entries: ReadonlyArray<readonly [string, string]>) {
+  const declarations = entries.map(([key, value]) => `  ${key}: ${value};`).join('\n');
+  return `${selector} {\n${declarations}\n}`;
+}
+
+export function createMedaThemeCss(theme: MedaThemeDefinition) {
+  const lightEntries = entriesForMode(theme.light);
+  const darkEntries = entriesForMode(theme.dark);
+  const darkSelector = `${theme.selector}.dark, ${theme.selector}[data-theme="dark"]`;
+
+  return [renderBlock(theme.selector, lightEntries), renderBlock(darkSelector, darkEntries)].join(
+    '\n\n'
+  );
+}


### PR DESCRIPTION
## Summary
- Adds provider-neutral auth controls under `@medalsocial/meda/auth` and re-exports them from `@medalsocial/meda/shell`.
- Adds `AppShell variant="auth"` branding shorthand while preserving existing `auth={...}` usage.
- Adds optional `@medalsocial/meda/auth/better-auth` adapter helpers without importing better-auth in the base package.

## Notes
- This branch is based on released `prod` because PR #72 is still blocked by branch policy while syncing the 1.3.0 release commit back to `dev`.
- Once #72 merges, this PR can be updated/rebased so the diff only contains the auth adoption work.

## Test Plan
- `pnpm exec vitest run --environment jsdom src/shell/app-shell-variants.test.tsx src/auth/auth-provider-button.test.tsx src/auth/better-auth.test.tsx`
- `pnpm typecheck`
- `pnpm build`
- `pnpm lint` (passes with existing warnings in kanban/list files)
- `pnpm check:stories` (passes with existing AppShell story-count warning)
- `pnpm test`