### PR TITLE
Render prop boundaries

### DIFF
--- a/.changeset/meda-package-recipes.md
+++ b/.changeset/meda-package-recipes.md
@@ -1,0 +1,5 @@
+---
+"@medalsocial/meda": minor
+---
+
+Add shell primitive and Next recipe package subpaths, plus registry metadata for copyable AppShell adoption recipes.

--- a/.changeset/meda-render-prop-boundaries.md
+++ b/.changeset/meda-render-prop-boundaries.md
@@ -1,0 +1,5 @@
+---
+"@medalsocial/meda": minor
+---
+
+Add render-boundary adapter props for auth provider buttons, shell rail links, and right panel tabs so consumers can integrate routers, analytics, and wrapper components while preserving Meda ARIA, state, and event props.

--- a/dist/auth/auth-provider-button.d.ts
+++ b/dist/auth/auth-provider-button.d.ts
@@ -1,4 +1,5 @@
 import type { ButtonHTMLAttributes, ReactNode } from 'react';
+import { type RenderElement } from '../lib/render-element.js';
 export type AuthProvider = 'google' | (string & {});
 export interface AuthProviderButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {
     provider?: AuthProvider;
@@ -8,5 +9,6 @@ export interface AuthProviderButtonProps extends Omit<ButtonHTMLAttributes<HTMLB
     loadingLabel?: ReactNode;
     lastUsed?: boolean;
     lastUsedLabel?: ReactNode;
+    render?: RenderElement<ButtonHTMLAttributes<HTMLButtonElement>>;
 }
-export declare function AuthProviderButton({ provider, label, icon, loading, loadingLabel, lastUsed, lastUsedLabel, disabled, className, type, ...props }: AuthProviderButtonProps): import("react/jsx-runtime").JSX.Element;
+export declare function AuthProviderButton({ provider, label, icon, loading, loadingLabel, lastUsed, lastUsedLabel, render, disabled, className, type, ...props }: AuthProviderButtonProps): string | number | bigint | boolean | Iterable<ReactNode> | Promise<string | number | bigint | boolean | import("react").ReactPortal | import("react").ReactElement<unknown, string | import("react").JSXElementConstructor<any>> | Iterable<ReactNode> | null | undefined> | import("react/jsx-runtime").JSX.Element | null | undefined;

--- a/dist/auth/auth-provider-button.js
+++ b/dist/auth/auth-provider-button.js
@@ -1,10 +1,25 @@
 'use client';
-import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
+import { jsx as _jsx, Fragment as _Fragment, jsxs as _jsxs } from "react/jsx-runtime";
+import { renderElement } from '../lib/render-element.js';
 import { cn } from '../lib/utils.js';
-export function AuthProviderButton({ provider, label, icon, loading = false, loadingLabel = 'Loading...', lastUsed = false, lastUsedLabel = 'Last used', disabled, className, type = 'button', ...props }) {
+export function AuthProviderButton({ provider, label, icon, loading = false, loadingLabel = 'Loading...', lastUsed = false, lastUsedLabel = 'Last used', render, disabled, className, type = 'button', ...props }) {
     const resolvedIcon = icon ?? (provider === 'google' ? _jsx(GoogleIcon, {}) : null);
     const isDisabled = disabled || loading;
-    return (_jsxs("button", { type: type, disabled: isDisabled, "aria-busy": loading || undefined, "data-provider": provider, "data-last-used": lastUsed || undefined, className: cn('relative inline-flex min-h-11 w-full items-center justify-center gap-3 rounded-md border border-border bg-background px-4 py-2.5 text-sm font-medium text-foreground shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-60', className), ...props, children: [resolvedIcon && (_jsx("span", { className: "flex size-5 shrink-0 items-center justify-center", "aria-hidden": "true", children: resolvedIcon })), _jsx("span", { className: "min-w-0 truncate", children: loading ? loadingLabel : label }), lastUsed && !loading && (_jsx("span", { "aria-hidden": "true", className: "ml-auto shrink-0 rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground", children: lastUsedLabel }))] }));
+    const children = (_jsxs(_Fragment, { children: [resolvedIcon && (_jsx("span", { className: "flex size-5 shrink-0 items-center justify-center", "aria-hidden": "true", children: resolvedIcon })), _jsx("span", { className: "min-w-0 truncate", children: loading ? loadingLabel : label }), lastUsed && !loading && (_jsx("span", { "aria-hidden": "true", className: "ml-auto shrink-0 rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground", children: lastUsedLabel }))] }));
+    const buttonProps = {
+        type,
+        disabled: isDisabled,
+        'aria-busy': loading || undefined,
+        'data-provider': provider,
+        'data-last-used': lastUsed || undefined,
+        className: cn('relative inline-flex min-h-11 w-full items-center justify-center gap-3 rounded-md border border-border bg-background px-4 py-2.5 text-sm font-medium text-foreground shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-60', className),
+        ...props,
+        children,
+    };
+    if (render) {
+        return renderElement(render, buttonProps);
+    }
+    return _jsx("button", { ...buttonProps });
 }
 function GoogleIcon() {
     return (_jsxs("svg", { viewBox: "0 0 24 24", className: "size-5", "aria-hidden": "true", children: [_jsx("path", { fill: "#4285F4", d: "M21.6 12.23c0-.82-.07-1.42-.22-2.05H12v3.72h5.51c-.11.92-.71 2.31-2.04 3.24l-.02.12 2.96 2.29.2.02c1.86-1.72 2.99-4.25 2.99-7.34z" }), _jsx("path", { fill: "#34A853", d: "M12 22c2.66 0 4.89-.88 6.52-2.39l-3.11-2.42c-.83.58-1.95.99-3.41.99a5.93 5.93 0 0 1-5.6-4.1l-.12.01-3.08 2.39-.04.11A9.85 9.85 0 0 0 12 22z" }), _jsx("path", { fill: "#FBBC05", d: "M6.4 14.08A6.17 6.17 0 0 1 6.07 12c0-.72.12-1.42.32-2.08l-.01-.13-3.12-2.42-.1.05A9.93 9.93 0 0 0 2.1 12c0 1.64.39 3.19 1.07 4.57l3.23-2.49z" }), _jsx("path", { fill: "#EA4335", d: "M12 5.82c1.85 0 3.1.8 3.81 1.47l2.78-2.72C16.88 2.98 14.66 2 12 2a9.85 9.85 0 0 0-8.84 5.42l3.22 2.5A5.96 5.96 0 0 1 12 5.82z" })] }));

--- a/dist/lib/render-element.d.ts
+++ b/dist/lib/render-element.d.ts
@@ -1,0 +1,9 @@
+import { type ReactElement, type ReactNode } from 'react';
+export type RenderElement<TProps extends {
+    className?: string;
+    children?: ReactNode;
+}> = ReactElement<Partial<TProps>>;
+export declare function renderElement<TProps extends {
+    className?: string;
+    children?: ReactNode;
+}>(render: RenderElement<TProps>, props: TProps): ReactNode;

--- a/dist/lib/render-element.js
+++ b/dist/lib/render-element.js
@@ -1,0 +1,27 @@
+import { cloneElement, isValidElement, } from 'react';
+import { cn } from './utils.js';
+function composeEventHandlers(consumerHandler, medaHandler) {
+    if (!consumerHandler)
+        return medaHandler;
+    if (!medaHandler)
+        return consumerHandler;
+    return (event) => {
+        consumerHandler(event);
+        if (!event.defaultPrevented) {
+            medaHandler(event);
+        }
+    };
+}
+export function renderElement(render, props) {
+    if (!isValidElement(render))
+        return null;
+    const renderProps = render.props;
+    const medaProps = props;
+    return cloneElement(render, {
+        ...renderProps,
+        ...medaProps,
+        className: cn(renderProps.className, medaProps.className),
+        onClick: composeEventHandlers(renderProps.onClick, medaProps.onClick),
+        onKeyDown: composeEventHandlers(renderProps.onKeyDown, medaProps.onKeyDown),
+    });
+}

--- a/dist/recipes/next.d.ts
+++ b/dist/recipes/next.d.ts
@@ -1,0 +1,46 @@
+export interface MedaRecipeFile {
+    path: string;
+    target: string;
+    type: 'registry:block' | 'registry:component' | 'registry:hook' | 'registry:lib';
+    content: string;
+}
+export interface MedaRecipe {
+    name: string;
+    title: string;
+    description: string;
+    dependencies: string[];
+    peerDependencies: string[];
+    cssVars: string[];
+    files: MedaRecipeFile[];
+    accessibility: string[];
+}
+export declare const nextAppShellRecipe: {
+    name: string;
+    title: string;
+    description: string;
+    dependencies: string[];
+    peerDependencies: string[];
+    cssVars: string[];
+    files: {
+        path: string;
+        target: string;
+        type: "registry:block";
+        content: string;
+    }[];
+    accessibility: string[];
+};
+export declare const nextRecipes: {
+    name: string;
+    title: string;
+    description: string;
+    dependencies: string[];
+    peerDependencies: string[];
+    cssVars: string[];
+    files: {
+        path: string;
+        target: string;
+        type: "registry:block";
+        content: string;
+    }[];
+    accessibility: string[];
+}[];

--- a/dist/recipes/next.js
+++ b/dist/recipes/next.js
@@ -1,0 +1,122 @@
+export const nextAppShellRecipe = {
+    name: 'meda-next-app-shell',
+    title: 'Meda Next AppShell',
+    description: 'Copyable Next.js App Router shell adapter with next/link routing, route-owned panel views, and auth controls.',
+    dependencies: ['@medalsocial/meda', 'lucide-react'],
+    peerDependencies: ['next', 'react', 'react-dom'],
+    cssVars: ['@medalsocial/meda/styles.css'],
+    files: [
+        {
+            path: 'registry/meda/meda-next-app-shell/meda-next-app-shell.tsx',
+            target: 'components/meda/meda-next-app-shell.tsx',
+            type: 'registry:block',
+            content: `\
+'use client'
+
+import Link from 'next/link'
+import type { ComponentProps, ReactNode } from 'react'
+import {
+  AppShell,
+  AuthError,
+  AuthNotice,
+  AuthOneTapSlot,
+  AuthProviderButton,
+  AuthProviderList,
+  MedaShellProvider,
+  PanelViewsProvider,
+  type AppDefinition,
+  type IconRailItem,
+  type PanelView,
+  type WorkspaceDefinition,
+} from '@medalsocial/meda/shell'
+
+export function MedaNextWorkspaceShell({
+  workspace,
+  apps,
+  iconItems,
+  activeIconId,
+  panelViews = [],
+  defaultPanelView,
+  children,
+}: {
+  workspace: WorkspaceDefinition
+  apps: AppDefinition[]
+  iconItems: IconRailItem[]
+  activeIconId?: string
+  panelViews?: PanelView[]
+  defaultPanelView?: string
+  children: ReactNode
+}) {
+  return (
+    <MedaShellProvider workspace={workspace} apps={apps}>
+      <AppShell
+        variant="workspace"
+        iconRail={{
+          mainItems: iconItems,
+          activeId: activeIconId,
+          renderLink: ({ item, linkProps }) => (
+            <Link {...linkProps} href={item.to} prefetch />
+          ),
+        }}
+        rightPanel={{ panelViews, defaultView: defaultPanelView }}
+      >
+        <PanelViewsProvider views={panelViews} defaultView={defaultPanelView}>
+          {children}
+        </PanelViewsProvider>
+      </AppShell>
+    </MedaShellProvider>
+  )
+}
+
+export function MedaNextAuthShell({
+  brandName,
+  brandMark,
+  appName,
+  tagline,
+  preview,
+  error,
+  notice,
+  onGoogleSignIn,
+}: {
+  brandName: ReactNode
+  brandMark?: ReactNode
+  appName?: ReactNode
+  tagline?: ReactNode
+  preview?: ReactNode
+  error?: ReactNode
+  notice?: ReactNode
+  onGoogleSignIn: ComponentProps<typeof AuthProviderButton>['onClick']
+}) {
+  return (
+    <MedaShellProvider workspace={{ id: 'auth', name: 'Auth', icon: brandMark }} apps={[]}>
+      <AppShell
+        variant="auth"
+        branding={{ brandName, brandMark, appName, tagline }}
+        preview={preview}
+      >
+        <AuthProviderList>
+          <AuthProviderButton
+            provider="google"
+            label="Continue with Google"
+            onClick={onGoogleSignIn}
+          />
+        </AuthProviderList>
+        <AuthNotice>{notice}</AuthNotice>
+        <AuthError>{error}</AuthError>
+        <AuthOneTapSlot />
+      </AppShell>
+    </MedaShellProvider>
+  )
+}
+`,
+        },
+    ],
+    accessibility: [
+        'Every drawer and panel keeps its accessible name from AppShell and RightPanel.',
+        'Custom link renderers must forward all linkProps to preserve aria-current, labels, handlers, and className.',
+        'Auth provider buttons keep the visible provider affordance separate from the accessible button name.',
+        'Route-owned panel views should expose headings inside their rendered panel content.',
+        'Reduced-motion behavior remains delegated to Meda shell motion tokens.',
+    ],
+};
+export const nextRecipes = [nextAppShellRecipe];

--- a/dist/shell/context-rail.js
+++ b/dist/shell/context-rail.js
@@ -15,7 +15,7 @@ import { jsx as _jsx, jsxs as _jsxs, Fragment as _Fragment } from "react/jsx-run
  * once <AppShellBody> ships as a ResizableShell Group.
  */
 import { PanelLeftClose, PanelLeftOpen } from 'lucide-react';
-import { useId, useRef, useState } from 'react';
+import { Fragment, useId, useRef, useState } from 'react';
 import { cn } from '../lib/utils.js';
 import { useMedaShell } from './shell-provider.js';
 import { useShellViewport } from './use-shell-viewport.js';
@@ -120,9 +120,15 @@ export function ContextRail({ appId, module, hidden = false, collapsible = true,
                                 : 'text-muted-foreground hover:bg-accent hover:text-foreground');
                             const IconComp = item.icon;
                             const inner = (_jsxs(_Fragment, { children: [_jsx(IconComp, { size: 16, "aria-hidden": "true", className: "shrink-0" }), _jsx("span", { className: "truncate", children: item.label }), item.shortcut && (_jsx("kbd", { className: "ml-auto font-mono text-[10px] text-muted-foreground", children: item.shortcut }))] }));
+                            const linkProps = {
+                                href: item.to,
+                                'aria-current': isActive ? 'page' : undefined,
+                                className: klass,
+                                children: inner,
+                            };
                             if (renderLink) {
-                                return renderLink({ item, isActive, className: klass, children: inner });
+                                return (_jsx(Fragment, { children: renderLink({ item, isActive, className: klass, children: inner, linkProps }) }, item.id));
                             }
-                            return (_jsx("a", { href: item.to, "aria-current": isActive ? 'page' : undefined, className: klass, children: inner }, item.id));
+                            return _jsx("a", { ...linkProps }, item.id);
                         }) })), module.render?.({ workspaceId: ctx.workspace.id, appId })] }), !collapsed && (_jsx(ResizeHandle, { currentWidth: width, onResize: handleResize, onCommit: handleCommit }))] }));
 }

--- a/dist/shell/icon-rail.d.ts
+++ b/dist/shell/icon-rail.d.ts
@@ -1,5 +1,5 @@
 import type { LucideIcon } from 'lucide-react';
-import type { ReactNode } from 'react';
+import type { AnchorHTMLAttributes, ReactNode } from 'react';
 export interface IconRailItem {
     id: string;
     label: string;
@@ -12,6 +12,7 @@ export interface IconRailRenderLinkArgs {
     isActive: boolean;
     className: string;
     children: ReactNode;
+    linkProps: AnchorHTMLAttributes<HTMLAnchorElement>;
 }
 export interface IconRailProps {
     mainItems: IconRailItem[];

--- a/dist/shell/icon-rail.js
+++ b/dist/shell/icon-rail.js
@@ -29,9 +29,16 @@ export function IconRail({ mainItems, utilityItems = [], footer, activeId, rende
         const klass = itemClass(isActive);
         const IconComp = item.icon;
         const inner = (_jsxs(_Fragment, { children: [_jsx(IconComp, { size: 22, "aria-hidden": "true" }), item.badge ? _jsx("span", { className: "absolute right-1 top-1", children: item.badge }) : null] }));
+        const linkProps = {
+            href: item.to,
+            'aria-label': item.label,
+            'aria-current': isActive ? 'page' : undefined,
+            className: 'contents',
+            children: inner,
+        };
         const linkContent = renderLink ? (
         // renderLink consumers receive the className so they can apply it themselves
-        renderLink({ item, isActive, className: klass, children: inner })) : (_jsx("a", { href: item.to, "aria-label": item.label, "aria-current": isActive ? 'page' : undefined, className: "contents", children: inner }));
+        renderLink({ item, isActive, className: klass, children: inner, linkProps })) : (_jsx("a", { ...linkProps }));
         return (_jsxs(Tooltip, { children: [_jsx(TooltipTrigger, { render: _jsx("span", { "data-testid": `icon-rail-trigger-${item.id}`, className: klass, children: linkContent }) }), _jsx(TooltipContent, { side: "right", children: item.label })] }, item.id));
     };
     return (_jsx(TooltipProvider, { children: _jsxs("nav", { "data-testid": "icon-rail", "aria-label": "Primary", className: cn('flex h-full w-[var(--shell-rail-width)] shrink-0 flex-col items-center bg-shell-rail py-3.5', className), children: [_jsx("div", { className: "flex flex-col items-center gap-1", children: mainItems.map(renderItem) }), utilityItems.length > 0 && (_jsxs(_Fragment, { children: [_jsx(RailDivider, { pinnedBottom: pinnedBottom, onToggle: () => setPinnedBottom((prev) => !prev) }), _jsx("div", { "data-testid": "utility-items-wrapper", className: cn('flex flex-col items-center gap-1', pinnedBottom && 'mt-auto'), children: utilityItems.map(renderItem) })] })), footer && (_jsx("div", { className: cn('pt-3', pinnedBottom || utilityItems.length === 0 ? 'mt-auto' : ''), children: footer }))] }) }));

--- a/dist/shell/index.d.ts
+++ b/dist/shell/index.d.ts
@@ -7,6 +7,7 @@ export { ContextRail } from './context-rail.js';
 export type { DragModeBannerProps } from './drag-mode-banner.js';
 export { DragModeBanner } from './drag-mode-banner.js';
 export * as Extras from './extras/index.js';
+export type { IconRailItem, IconRailProps, IconRailRenderLinkArgs } from './icon-rail.js';
 export { IconRail, RailDivider } from './icon-rail.js';
 export type { ShellStorageAdapter } from './layout-state.js';
 export { createLocalStorageAdapter } from './layout-state.js';

--- a/dist/shell/index.js
+++ b/dist/shell/index.js
@@ -13,7 +13,6 @@ export { ContextRail } from './context-rail.js';
 export { DragModeBanner } from './drag-mode-banner.js';
 // Extras (legacy components ported during Phase 15 — opt-in for apps that need them)
 export * as Extras from './extras/index.js';
-// Rails + main + panel
 export { IconRail, RailDivider } from './icon-rail.js';
 // Storage adapter (consumers may want to provide their own)
 export { createLocalStorageAdapter } from './layout-state.js';

--- a/dist/shell/internal/mobile-drawers.js
+++ b/dist/shell/internal/mobile-drawers.js
@@ -34,15 +34,22 @@ const menuItemClassName = 'flex items-center gap-2 rounded-md px-3 py-2 text-sm 
 function MenuDrawerItem({ item, isActive, onClose, renderLink, }) {
     const Icon = item.icon;
     const children = (_jsxs(_Fragment, { children: [_jsx(Icon, { size: 18, "aria-hidden": "true" }), _jsx("span", { children: item.label })] }));
+    const className = cn(menuItemClassName, isActive && 'bg-accent text-foreground');
+    const linkProps = {
+        href: item.to,
+        className,
+        children,
+    };
     if (renderLink) {
         return closeAfterLinkClick(renderLink({
             item,
             isActive,
-            className: cn(menuItemClassName, isActive && 'bg-accent text-foreground'),
+            className,
             children,
+            linkProps,
         }), onClose);
     }
-    return (_jsx("a", { href: item.to, onClick: onClose, className: menuItemClassName, children: children }));
+    return closeAfterLinkClick(_jsx("a", { ...linkProps }), onClose);
 }
 function closeAfterLinkClick(link, onClose) {
     if (!isValidElement(link)) {

--- a/dist/shell/primitives.d.ts
+++ b/dist/shell/primitives.d.ts
@@ -1,0 +1,9 @@
+export type { ShellStorageAdapter } from './layout-state.js';
+export { createLocalStorageAdapter } from './layout-state.js';
+export type { PanelViewsProviderProps } from './panel-views-provider.js';
+export { PanelViewsProvider } from './panel-views-provider.js';
+export { ResizableHandle, ResizableShell, ResizableShellPanel } from './resizable-shell.js';
+export type { MedaShellProviderProps } from './shell-provider.js';
+export { MedaShellProvider, useMedaShell, useShellSelection } from './shell-provider.js';
+export type { AppDefinition, CommandDefinition, ContextItem, ContextModule, MobileBottomNavItem, PanelMode, PanelView, ShellLinkRenderArgs, ShellRenderContext, ShellViewport, ThemeAdapter, WorkspaceDefinition, } from './types.js';
+export { useShellViewport } from './use-shell-viewport.js';

--- a/dist/shell/primitives.js
+++ b/dist/shell/primitives.js
@@ -1,0 +1,7 @@
+// State and layout primitives for consumers that want Meda shell behavior
+// without importing the full styled shell barrel.
+export { createLocalStorageAdapter } from './layout-state.js';
+export { PanelViewsProvider } from './panel-views-provider.js';
+export { ResizableHandle, ResizableShell, ResizableShellPanel } from './resizable-shell.js';
+export { MedaShellProvider, useMedaShell, useShellSelection } from './shell-provider.js';
+export { useShellViewport } from './use-shell-viewport.js';

--- a/dist/shell/right-panel.d.ts
+++ b/dist/shell/right-panel.d.ts
@@ -1,3 +1,4 @@
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
 import type { PanelMode, PanelView } from './types.js';
 export interface RightPanelProps {
     /** Views to render as tabs in the panel header. */
@@ -10,6 +11,16 @@ export interface RightPanelProps {
      * If only ['panel'], the cycle button is hidden.
      */
     modes?: PanelMode[];
+    renderTab?: (args: RightPanelTabRenderArgs) => ReactNode;
     className?: string;
 }
-export declare function RightPanel({ panelViews, defaultView, modes, className, }: RightPanelProps): import("react/jsx-runtime").JSX.Element | null;
+export interface RightPanelTabRenderArgs {
+    view: PanelView;
+    isActive: boolean;
+    buttonProps: RightPanelTabButtonProps;
+    children: ReactNode;
+}
+export type RightPanelTabButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+    'data-active'?: boolean;
+};
+export declare function RightPanel({ panelViews, defaultView, modes, renderTab, className, }: RightPanelProps): import("react/jsx-runtime").JSX.Element | null;

--- a/dist/shell/right-panel.js
+++ b/dist/shell/right-panel.js
@@ -1,5 +1,5 @@
 'use client';
-import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
+import { jsx as _jsx, Fragment as _Fragment, jsxs as _jsxs } from "react/jsx-runtime";
 /**
  * RightPanel — spec §12
  *
@@ -16,7 +16,7 @@ import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
  * TODO(phase-15-refactor): swap to ResizableShell once AppShellBody is a PanelGroup
  */
 import { Maximize2, Minimize2, X } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { Fragment, useEffect, useRef, useState } from 'react';
 import { cn } from '../lib/utils.js';
 import { useResolvedPanelViews } from './panel-views-provider.js';
 import { useMedaShell } from './shell-provider.js';
@@ -63,7 +63,7 @@ function ResizeHandle({ currentWidth, onResize, onCommit }) {
 // ---------------------------------------------------------------------------
 // RightPanel
 // ---------------------------------------------------------------------------
-export function RightPanel({ panelViews = EMPTY_PANEL_VIEWS, defaultView, modes = ['panel', 'expanded', 'fullscreen'], className, }) {
+export function RightPanel({ panelViews = EMPTY_PANEL_VIEWS, defaultView, modes = ['panel', 'expanded', 'fullscreen'], renderTab, className, }) {
     const band = useShellViewport();
     const ctx = useMedaShell();
     const { mode, activeView, width, setMode, setActiveView, setWidth } = ctx.panel;
@@ -132,8 +132,20 @@ export function RightPanel({ panelViews = EMPTY_PANEL_VIEWS, defaultView, modes 
     return (_jsx("aside", { "data-meda-panel-mode": mode, "aria-hidden": mode === 'closed' ? 'true' : undefined, className: cn('relative h-full shrink-0 overflow-hidden border-l border-shell-border bg-shell-panel', 'transition-[width] ease-[var(--motion-ease)] duration-[var(--motion-panel)]', mode === 'fullscreen' && 'fixed inset-0 h-screen w-screen border-none', zIndexClass, className), style: widthStyle, children: mode !== 'closed' && (_jsxs("div", { className: "flex h-full flex-col", children: [_jsxs("div", { className: "flex items-center justify-between border-b border-shell-border px-3 py-2", children: [_jsx("div", { className: "flex items-center gap-1", children: resolvedPanelViews.map((view) => {
                                 const isActive = view.id === activeView;
                                 const Icon = view.icon;
-                                return (_jsxs("button", { type: "button", "aria-current": isActive ? 'true' : undefined, onClick: () => setActiveView(view.id), className: cn('inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium transition-colors', isActive
+                                const children = (_jsxs(_Fragment, { children: [_jsx(Icon, { size: 14, "aria-hidden": "true" }), _jsx("span", { children: view.label })] }));
+                                const buttonProps = {
+                                    type: 'button',
+                                    'aria-current': isActive ? 'true' : undefined,
+                                    'data-active': isActive || undefined,
+                                    onClick: () => setActiveView(view.id),
+                                    className: cn('inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium transition-colors', isActive
                                         ? 'bg-accent text-accent-foreground'
-                                        : 'text-muted-foreground hover:bg-accent hover:text-foreground'), children: [_jsx(Icon, { size: 14, "aria-hidden": "true" }), _jsx("span", { children: view.label })] }, view.id));
+                                        : 'text-muted-foreground hover:bg-accent hover:text-foreground'),
+                                    children,
+                                };
+                                if (renderTab) {
+                                    return (_jsx(Fragment, { children: renderTab({ view, isActive, buttonProps, children }) }, view.id));
+                                }
+                                return _jsx("button", { ...buttonProps }, view.id);
                             }) }), _jsxs("div", { className: "flex items-center gap-1", children: [modes.length > 1 && (_jsx("button", { type: "button", "aria-label": cycleAriaLabel, onClick: cycleOpenMode, className: "inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground", children: mode === 'fullscreen' ? (_jsx(Minimize2, { size: 14, "aria-hidden": "true" })) : (_jsx(Maximize2, { size: 14, "aria-hidden": "true" })) })), _jsx("button", { type: "button", "aria-label": "Close panel", onClick: () => setMode('closed'), className: "inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground", children: _jsx(X, { size: 14, "aria-hidden": "true" }) })] })] }), _jsx("div", { className: "flex-1 overflow-y-auto", children: activePanelView != null ? (activePanelView.render(renderCtx)) : (_jsx("div", { className: "p-4 text-muted-foreground text-sm", children: "No panel view selected" })) }), mode === 'panel' && (_jsx(ResizeHandle, { currentWidth: resolvedWidth, onResize: handleResize, onCommit: handleCommit }))] })) }));
 }

--- a/dist/shell/types.d.ts
+++ b/dist/shell/types.d.ts
@@ -1,5 +1,5 @@
 import type { LucideIcon } from 'lucide-react';
-import type { ReactNode } from 'react';
+import type { AnchorHTMLAttributes, ReactNode } from 'react';
 export interface AppDefinition {
     id: string;
     label: string;
@@ -49,6 +49,7 @@ export interface ShellLinkRenderArgs {
     isActive: boolean;
     className: string;
     children: ReactNode;
+    linkProps: AnchorHTMLAttributes<HTMLAnchorElement>;
 }
 export interface CommandDefinition {
     id: string;

--- a/package.json
+++ b/package.json
@@ -80,6 +80,14 @@
     },
     "./styles/tokens": {
       "default": "./dist/styles/tokens.css"
+    },
+    "./shell/primitives": {
+      "types": "./dist/shell/primitives.d.ts",
+      "default": "./dist/shell/primitives.js"
+    },
+    "./recipes/next": {
+      "types": "./dist/recipes/next.d.ts",
+      "default": "./dist/recipes/next.js"
     }
   },
   "sideEffects": [

--- a/registry/README.md
+++ b/registry/README.md
@@ -11,6 +11,7 @@ Current items:
 - `meda-shell`
 - `meda-shell-state`
 - `meda-workbench-layout`
+- `meda-next-app-shell`
 - `meda-marketing`
 - `meda-marketing-callout`
 - `meda-marketing-contact`

--- a/registry/r/meda-next-app-shell.json
+++ b/registry/r/meda-next-app-shell.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "meda-next-app-shell",
+  "type": "registry:block",
+  "title": "Meda Next AppShell",
+  "description": "Install a copyable Next.js App Router shell adapter with next/link routing, route-owned panel views, and auth controls.",
+  "dependencies": ["@medalsocial/meda", "lucide-react"],
+  "files": [
+    {
+      "path": "registry/meda/meda-next-app-shell/meda-next-app-shell.tsx",
+      "content": "export { nextAppShellRecipe as medaNextAppShellRecipe } from '@medalsocial/meda/recipes/next'\n",
+      "type": "registry:block",
+      "target": "components/meda/meda-next-app-shell.tsx"
+    }
+  ],
+  "meta": {
+    "peerDependencies": ["next", "react", "react-dom"],
+    "cssVars": ["@medalsocial/meda/styles.css"],
+    "accessibility": [
+      "Forward all linkProps from rail render callbacks.",
+      "Panel views should include a visible or visually-hidden heading.",
+      "Auth provider buttons preserve accessible button names."
+    ]
+  }
+}

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -50,6 +50,21 @@
     },
     {
       "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+      "name": "meda-next-app-shell",
+      "type": "registry:block",
+      "title": "Meda Next AppShell",
+      "description": "Install a copyable Next.js App Router shell adapter.",
+      "dependencies": ["@medalsocial/meda", "lucide-react"],
+      "files": [
+        {
+          "path": "registry/meda/meda-next-app-shell/meda-next-app-shell.tsx",
+          "type": "registry:block",
+          "target": "components/meda/meda-next-app-shell.tsx"
+        }
+      ]
+    },
+    {
+      "$schema": "https://ui.shadcn.com/schema/registry-item.json",
       "name": "meda-marketing",
       "type": "registry:block",
       "title": "Meda Marketing",

--- a/registry/scripts/validate-registry.mjs
+++ b/registry/scripts/validate-registry.mjs
@@ -10,6 +10,7 @@ const files = [
   'r/meda-shell.json',
   'r/meda-shell-state.json',
   'r/meda-workbench-layout.json',
+  'r/meda-next-app-shell.json',
   'r/meda-marketing.json',
   'r/meda-marketing-callout.json',
   'r/meda-marketing-contact.json',
@@ -44,6 +45,15 @@ for (const [file, json] of parsedFiles.entries()) {
     `${file} must include a registry type.`
   );
   assert(Array.isArray(json?.dependencies), `${file} must declare dependencies.`);
+  if (json.meta?.peerDependencies) {
+    assert(Array.isArray(json.meta.peerDependencies), `${file} peerDependencies must be an array.`);
+  }
+  if (json.meta?.accessibility) {
+    assert(
+      Array.isArray(json.meta.accessibility) && json.meta.accessibility.length > 0,
+      `${file} accessibility metadata must be a non-empty array.`
+    );
+  }
   assert(
     Array.isArray(json?.files) && json.files.length > 0,
     `${file} must include at least one file entry.`

--- a/src/auth/auth-provider-button.test.tsx
+++ b/src/auth/auth-provider-button.test.tsx
@@ -62,6 +62,30 @@ describe('auth controls', () => {
     consoleError.mockRestore();
   });
 
+  it('passes Meda button props into a custom rendered auth button', () => {
+    const onClick = vi.fn();
+    const customClick = vi.fn();
+
+    render(
+      <AuthProviderButton
+        provider="google"
+        label="Continue with Google"
+        lastUsed
+        onClick={onClick}
+        render={<button type="button" data-testid="custom-auth" onClick={customClick} />}
+      />
+    );
+
+    const button = screen.getByTestId('custom-auth');
+    expect(button).toHaveAttribute('data-provider', 'google');
+    expect(button).toHaveAttribute('data-last-used', 'true');
+    expect(button).toHaveAccessibleName('Continue with Google');
+
+    fireEvent.click(button);
+    expect(customClick).toHaveBeenCalledTimes(1);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
   it('renders auth messages only when content is supplied', () => {
     const { container } = render(
       <>

--- a/src/auth/auth-provider-button.tsx
+++ b/src/auth/auth-provider-button.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { ButtonHTMLAttributes, ReactNode } from 'react';
+import { type RenderElement, renderElement } from '../lib/render-element.js';
 import { cn } from '../lib/utils.js';
 
 export type AuthProvider = 'google' | (string & {});
@@ -14,7 +15,13 @@ export interface AuthProviderButtonProps
   loadingLabel?: ReactNode;
   lastUsed?: boolean;
   lastUsedLabel?: ReactNode;
+  render?: RenderElement<ButtonHTMLAttributes<HTMLButtonElement>>;
 }
+
+type AuthProviderButtonRenderProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  'data-provider'?: string;
+  'data-last-used'?: boolean;
+};
 
 export function AuthProviderButton({
   provider,
@@ -24,6 +31,7 @@ export function AuthProviderButton({
   loadingLabel = 'Loading...',
   lastUsed = false,
   lastUsedLabel = 'Last used',
+  render,
   disabled,
   className,
   type = 'button',
@@ -32,19 +40,8 @@ export function AuthProviderButton({
   const resolvedIcon = icon ?? (provider === 'google' ? <GoogleIcon /> : null);
   const isDisabled = disabled || loading;
 
-  return (
-    <button
-      type={type}
-      disabled={isDisabled}
-      aria-busy={loading || undefined}
-      data-provider={provider}
-      data-last-used={lastUsed || undefined}
-      className={cn(
-        'relative inline-flex min-h-11 w-full items-center justify-center gap-3 rounded-md border border-border bg-background px-4 py-2.5 text-sm font-medium text-foreground shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-60',
-        className
-      )}
-      {...props}
-    >
+  const children = (
+    <>
       {resolvedIcon && (
         <span className="flex size-5 shrink-0 items-center justify-center" aria-hidden="true">
           {resolvedIcon}
@@ -59,8 +56,28 @@ export function AuthProviderButton({
           {lastUsedLabel}
         </span>
       )}
-    </button>
+    </>
   );
+
+  const buttonProps = {
+    type,
+    disabled: isDisabled,
+    'aria-busy': loading || undefined,
+    'data-provider': provider,
+    'data-last-used': lastUsed || undefined,
+    className: cn(
+      'relative inline-flex min-h-11 w-full items-center justify-center gap-3 rounded-md border border-border bg-background px-4 py-2.5 text-sm font-medium text-foreground shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-60',
+      className
+    ),
+    ...props,
+    children,
+  } satisfies AuthProviderButtonRenderProps;
+
+  if (render) {
+    return renderElement(render, buttonProps);
+  }
+
+  return <button {...buttonProps} />;
 }
 
 function GoogleIcon() {

--- a/src/lib/render-element.tsx
+++ b/src/lib/render-element.tsx
@@ -1,0 +1,50 @@
+import {
+  cloneElement,
+  isValidElement,
+  type KeyboardEventHandler,
+  type MouseEventHandler,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
+import { cn } from './utils.js';
+
+export type RenderElement<TProps extends { className?: string; children?: ReactNode }> =
+  ReactElement<Partial<TProps>>;
+
+type EventProps = {
+  onClick?: MouseEventHandler<HTMLElement>;
+  onKeyDown?: KeyboardEventHandler<HTMLElement>;
+};
+
+function composeEventHandlers<Event extends { defaultPrevented: boolean }>(
+  consumerHandler: ((event: Event) => void) | undefined,
+  medaHandler: ((event: Event) => void) | undefined
+) {
+  if (!consumerHandler) return medaHandler;
+  if (!medaHandler) return consumerHandler;
+
+  return (event: Event) => {
+    consumerHandler(event);
+    if (!event.defaultPrevented) {
+      medaHandler(event);
+    }
+  };
+}
+
+export function renderElement<TProps extends { className?: string; children?: ReactNode }>(
+  render: RenderElement<TProps>,
+  props: TProps
+): ReactNode {
+  if (!isValidElement(render)) return null;
+
+  const renderProps = render.props as Partial<TProps> & EventProps;
+  const medaProps = props as TProps & EventProps;
+
+  return cloneElement(render, {
+    ...renderProps,
+    ...medaProps,
+    className: cn(renderProps.className, medaProps.className),
+    onClick: composeEventHandlers(renderProps.onClick, medaProps.onClick),
+    onKeyDown: composeEventHandlers(renderProps.onKeyDown, medaProps.onKeyDown),
+  } as Partial<TProps>);
+}

--- a/src/recipes/next.test.ts
+++ b/src/recipes/next.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { nextAppShellRecipe, nextRecipes } from './next.js';
+
+describe('Next recipes', () => {
+  it('publishes copyable Next AppShell recipe metadata', () => {
+    expect(nextRecipes).toContain(nextAppShellRecipe);
+    expect(nextAppShellRecipe.name).toBe('meda-next-app-shell');
+    expect(nextAppShellRecipe.dependencies).toContain('@medalsocial/meda');
+    expect(nextAppShellRecipe.peerDependencies).toEqual(
+      expect.arrayContaining(['next', 'react', 'react-dom'])
+    );
+    expect(nextAppShellRecipe.files[0]?.content).toContain('next/link');
+  });
+
+  it('passes route panel views to AppShell on first render', () => {
+    expect(nextAppShellRecipe.files[0]?.content).toContain(
+      'rightPanel={{ panelViews, defaultView: defaultPanelView }}'
+    );
+    expect(nextAppShellRecipe.files[0]?.content).not.toContain('panelViews: []');
+  });
+
+  it('documents accessibility and composition contracts', () => {
+    expect(nextAppShellRecipe.accessibility).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('linkProps'),
+        expect.stringContaining('Auth provider buttons'),
+      ])
+    );
+  });
+});

--- a/src/recipes/next.ts
+++ b/src/recipes/next.ts
@@ -1,0 +1,142 @@
+export interface MedaRecipeFile {
+  path: string;
+  target: string;
+  type: 'registry:block' | 'registry:component' | 'registry:hook' | 'registry:lib';
+  content: string;
+}
+
+export interface MedaRecipe {
+  name: string;
+  title: string;
+  description: string;
+  dependencies: string[];
+  peerDependencies: string[];
+  cssVars: string[];
+  files: MedaRecipeFile[];
+  accessibility: string[];
+}
+
+export const nextAppShellRecipe = {
+  name: 'meda-next-app-shell',
+  title: 'Meda Next AppShell',
+  description:
+    'Copyable Next.js App Router shell adapter with next/link routing, route-owned panel views, and auth controls.',
+  dependencies: ['@medalsocial/meda', 'lucide-react'],
+  peerDependencies: ['next', 'react', 'react-dom'],
+  cssVars: ['@medalsocial/meda/styles.css'],
+  files: [
+    {
+      path: 'registry/meda/meda-next-app-shell/meda-next-app-shell.tsx',
+      target: 'components/meda/meda-next-app-shell.tsx',
+      type: 'registry:block',
+      content: `\
+'use client'
+
+import Link from 'next/link'
+import type { ComponentProps, ReactNode } from 'react'
+import {
+  AppShell,
+  AuthError,
+  AuthNotice,
+  AuthOneTapSlot,
+  AuthProviderButton,
+  AuthProviderList,
+  MedaShellProvider,
+  PanelViewsProvider,
+  type AppDefinition,
+  type IconRailItem,
+  type PanelView,
+  type WorkspaceDefinition,
+} from '@medalsocial/meda/shell'
+
+export function MedaNextWorkspaceShell({
+  workspace,
+  apps,
+  iconItems,
+  activeIconId,
+  panelViews = [],
+  defaultPanelView,
+  children,
+}: {
+  workspace: WorkspaceDefinition
+  apps: AppDefinition[]
+  iconItems: IconRailItem[]
+  activeIconId?: string
+  panelViews?: PanelView[]
+  defaultPanelView?: string
+  children: ReactNode
+}) {
+  return (
+    <MedaShellProvider workspace={workspace} apps={apps}>
+      <AppShell
+        variant="workspace"
+        iconRail={{
+          mainItems: iconItems,
+          activeId: activeIconId,
+          renderLink: ({ item, linkProps }) => (
+            <Link {...linkProps} href={item.to} prefetch />
+          ),
+        }}
+        rightPanel={{ panelViews, defaultView: defaultPanelView }}
+      >
+        <PanelViewsProvider views={panelViews} defaultView={defaultPanelView}>
+          {children}
+        </PanelViewsProvider>
+      </AppShell>
+    </MedaShellProvider>
+  )
+}
+
+export function MedaNextAuthShell({
+  brandName,
+  brandMark,
+  appName,
+  tagline,
+  preview,
+  error,
+  notice,
+  onGoogleSignIn,
+}: {
+  brandName: ReactNode
+  brandMark?: ReactNode
+  appName?: ReactNode
+  tagline?: ReactNode
+  preview?: ReactNode
+  error?: ReactNode
+  notice?: ReactNode
+  onGoogleSignIn: ComponentProps<typeof AuthProviderButton>['onClick']
+}) {
+  return (
+    <MedaShellProvider workspace={{ id: 'auth', name: 'Auth', icon: brandMark }} apps={[]}>
+      <AppShell
+        variant="auth"
+        branding={{ brandName, brandMark, appName, tagline }}
+        preview={preview}
+      >
+        <AuthProviderList>
+          <AuthProviderButton
+            provider="google"
+            label="Continue with Google"
+            onClick={onGoogleSignIn}
+          />
+        </AuthProviderList>
+        <AuthNotice>{notice}</AuthNotice>
+        <AuthError>{error}</AuthError>
+        <AuthOneTapSlot />
+      </AppShell>
+    </MedaShellProvider>
+  )
+}
+`,
+    },
+  ],
+  accessibility: [
+    'Every drawer and panel keeps its accessible name from AppShell and RightPanel.',
+    'Custom link renderers must forward all linkProps to preserve aria-current, labels, handlers, and className.',
+    'Auth provider buttons keep the visible provider affordance separate from the accessible button name.',
+    'Route-owned panel views should expose headings inside their rendered panel content.',
+    'Reduced-motion behavior remains delegated to Meda shell motion tokens.',
+  ],
+} satisfies MedaRecipe;
+
+export const nextRecipes = [nextAppShellRecipe] satisfies MedaRecipe[];

--- a/src/shell/app-shell-workspace.test.tsx
+++ b/src/shell/app-shell-workspace.test.tsx
@@ -252,6 +252,35 @@ describe('AppShellWorkspace', () => {
     expect(screen.getByTestId('mobile-drawer-state')).toHaveTextContent('closed');
   });
 
+  it('keeps mobile menu linkProps safe to spread without embedding close handler', () => {
+    (useShellViewport as ReturnType<typeof vi.fn>).mockReturnValue('mobile');
+    let linkPropsOnClick: unknown = null;
+
+    render(
+      <Provider>
+        <MobileDrawerStateProbe />
+        <AppShellWorkspace
+          iconRail={{
+            activeId: 'i',
+            mainItems: [{ id: 'i', label: 'Inbox', to: '/i', icon: Inbox }],
+            renderLink: ({ item, linkProps }) => {
+              linkPropsOnClick = linkProps.onClick;
+              return <a {...linkProps} data-testid={`spread-mobile-link-${item.id}`} />;
+            },
+          }}
+        >
+          <main aria-label="content">hi</main>
+        </AppShellWorkspace>
+      </Provider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Menu' }));
+    expect(linkPropsOnClick).toBeUndefined();
+
+    fireEvent.click(screen.getByTestId('spread-mobile-link-i'));
+    expect(screen.getByTestId('mobile-drawer-state')).toHaveTextContent('closed');
+  });
+
   it('renders mobile context module custom content with the context rail app id', () => {
     (useShellViewport as ReturnType<typeof vi.fn>).mockReturnValue('mobile');
 

--- a/src/shell/context-rail.test.tsx
+++ b/src/shell/context-rail.test.tsx
@@ -363,6 +363,26 @@ describe('ContextRail — module items rendering', () => {
     expect(screen.queryAllByRole('link')).toHaveLength(0);
   });
 
+  it('renderLink receives default link props for route adapters', () => {
+    render(
+      <Wrapper>
+        <ContextRail
+          appId="mail"
+          module={MODULE}
+          activeItemId="inbox"
+          renderLink={({ item, linkProps }) => (
+            <a {...linkProps} data-testid={`route-link-${item.id}`} data-route-link="true" />
+          )}
+        />
+      </Wrapper>
+    );
+
+    const inboxLink = screen.getByTestId('route-link-inbox');
+    expect(inboxLink).toHaveAttribute('href', '/inbox');
+    expect(inboxLink).toHaveAttribute('aria-current', 'page');
+    expect(inboxLink).toHaveAttribute('data-route-link', 'true');
+  });
+
   it('item with shortcut renders keyboard shortcut text', () => {
     const moduleWithShortcut: ContextModule = {
       id: 'mail',

--- a/src/shell/context-rail.tsx
+++ b/src/shell/context-rail.tsx
@@ -16,8 +16,8 @@
  */
 
 import { PanelLeftClose, PanelLeftOpen } from 'lucide-react';
-import type { ReactNode, PointerEvent as ReactPointerEvent } from 'react';
-import { useId, useRef, useState } from 'react';
+import type { AnchorHTMLAttributes, ReactNode, PointerEvent as ReactPointerEvent } from 'react';
+import { Fragment, useId, useRef, useState } from 'react';
 import { cn } from '../lib/utils.js';
 import { useMedaShell } from './shell-provider.js';
 import type { ContextModule, ShellLinkRenderArgs } from './types.js';
@@ -269,19 +269,21 @@ export function ContextRail({
                 </>
               );
 
+              const linkProps = {
+                href: item.to,
+                'aria-current': isActive ? 'page' : undefined,
+                className: klass,
+                children: inner,
+              } satisfies AnchorHTMLAttributes<HTMLAnchorElement>;
+
               if (renderLink) {
-                return renderLink({ item, isActive, className: klass, children: inner });
+                return (
+                  <Fragment key={item.id}>
+                    {renderLink({ item, isActive, className: klass, children: inner, linkProps })}
+                  </Fragment>
+                );
               }
-              return (
-                <a
-                  key={item.id}
-                  href={item.to}
-                  aria-current={isActive ? 'page' : undefined}
-                  className={klass}
-                >
-                  {inner}
-                </a>
-              );
+              return <a key={item.id} {...linkProps} />;
             })}
           </nav>
         )}

--- a/src/shell/icon-rail.test.tsx
+++ b/src/shell/icon-rail.test.tsx
@@ -155,6 +155,26 @@ describe('IconRail', () => {
     expect(screen.getByTestId('link-settings')).toBeInTheDocument();
   });
 
+  it('renderLink receives default link props for router adapters', () => {
+    render(
+      <Wrapper>
+        <IconRail
+          mainItems={mainItems}
+          activeId="inbox"
+          renderLink={({ item, linkProps }) => (
+            <a {...linkProps} data-testid={`router-link-${item.id}`} data-router-link="true" />
+          )}
+        />
+      </Wrapper>
+    );
+
+    const inboxLink = screen.getByTestId('router-link-inbox');
+    expect(inboxLink).toHaveAttribute('href', '/inbox');
+    expect(inboxLink).toHaveAttribute('aria-label', 'Inbox');
+    expect(inboxLink).toHaveAttribute('aria-current', 'page');
+    expect(inboxLink).toHaveAttribute('data-router-link', 'true');
+  });
+
   it('utilityItems render below mainItems with divider between', () => {
     render(
       <Wrapper>

--- a/src/shell/icon-rail.tsx
+++ b/src/shell/icon-rail.tsx
@@ -2,7 +2,7 @@
 
 import type { LucideIcon } from 'lucide-react';
 import { ChevronDown, ChevronUp } from 'lucide-react';
-import type { ReactNode } from 'react';
+import type { AnchorHTMLAttributes, ReactNode } from 'react';
 import { useState } from 'react';
 import {
   Tooltip,
@@ -30,6 +30,7 @@ export interface IconRailRenderLinkArgs {
   isActive: boolean;
   className: string;
   children: ReactNode;
+  linkProps: AnchorHTMLAttributes<HTMLAnchorElement>;
 }
 
 export interface IconRailProps {
@@ -114,18 +115,19 @@ export function IconRail({
       </>
     );
 
+    const linkProps = {
+      href: item.to,
+      'aria-label': item.label,
+      'aria-current': isActive ? 'page' : undefined,
+      className: 'contents',
+      children: inner,
+    } satisfies AnchorHTMLAttributes<HTMLAnchorElement>;
+
     const linkContent = renderLink ? (
       // renderLink consumers receive the className so they can apply it themselves
-      renderLink({ item, isActive, className: klass, children: inner })
+      renderLink({ item, isActive, className: klass, children: inner, linkProps })
     ) : (
-      <a
-        href={item.to}
-        aria-label={item.label}
-        aria-current={isActive ? 'page' : undefined}
-        className="contents"
-      >
-        {inner}
-      </a>
+      <a {...linkProps} />
     );
 
     return (

--- a/src/shell/index.ts
+++ b/src/shell/index.ts
@@ -30,6 +30,7 @@ export { DragModeBanner } from './drag-mode-banner.js';
 // Extras (legacy components ported during Phase 15 — opt-in for apps that need them)
 export * as Extras from './extras/index.js';
 // Rails + main + panel
+export type { IconRailItem, IconRailProps, IconRailRenderLinkArgs } from './icon-rail.js';
 export { IconRail, RailDivider } from './icon-rail.js';
 export type { ShellStorageAdapter } from './layout-state.js';
 // Storage adapter (consumers may want to provide their own)

--- a/src/shell/internal/mobile-drawers.tsx
+++ b/src/shell/internal/mobile-drawers.tsx
@@ -167,24 +167,27 @@ function MenuDrawerItem({
       <span>{item.label}</span>
     </>
   );
+  const className = cn(menuItemClassName, isActive && 'bg-accent text-foreground');
+  const linkProps = {
+    href: item.to,
+    className,
+    children,
+  };
 
   if (renderLink) {
     return closeAfterLinkClick(
       renderLink({
         item,
         isActive,
-        className: cn(menuItemClassName, isActive && 'bg-accent text-foreground'),
+        className,
         children,
+        linkProps,
       }),
       onClose
     );
   }
 
-  return (
-    <a href={item.to} onClick={onClose} className={menuItemClassName}>
-      {children}
-    </a>
-  );
+  return closeAfterLinkClick(<a {...linkProps} />, onClose);
 }
 
 type MenuLinkElementProps = {

--- a/src/shell/primitives.ts
+++ b/src/shell/primitives.ts
@@ -1,0 +1,25 @@
+// State and layout primitives for consumers that want Meda shell behavior
+// without importing the full styled shell barrel.
+
+export type { ShellStorageAdapter } from './layout-state.js';
+export { createLocalStorageAdapter } from './layout-state.js';
+export type { PanelViewsProviderProps } from './panel-views-provider.js';
+export { PanelViewsProvider } from './panel-views-provider.js';
+export { ResizableHandle, ResizableShell, ResizableShellPanel } from './resizable-shell.js';
+export type { MedaShellProviderProps } from './shell-provider.js';
+export { MedaShellProvider, useMedaShell, useShellSelection } from './shell-provider.js';
+export type {
+  AppDefinition,
+  CommandDefinition,
+  ContextItem,
+  ContextModule,
+  MobileBottomNavItem,
+  PanelMode,
+  PanelView,
+  ShellLinkRenderArgs,
+  ShellRenderContext,
+  ShellViewport,
+  ThemeAdapter,
+  WorkspaceDefinition,
+} from './types.js';
+export { useShellViewport } from './use-shell-viewport.js';

--- a/src/shell/right-panel.test.tsx
+++ b/src/shell/right-panel.test.tsx
@@ -298,6 +298,27 @@ describe('RightPanel — panelViews', () => {
     expect(inspectorTab).toHaveAttribute('aria-current', 'true');
   });
 
+  it('passes tab props into custom rendered panel tabs', () => {
+    render(
+      <Wrapper mode="panel" activeView="inspector">
+        <RightPanel
+          panelViews={VIEWS}
+          renderTab={({ view, buttonProps }) => (
+            <button {...buttonProps} type="button" data-testid={`panel-tab-${view.id}`} />
+          )}
+        />
+      </Wrapper>
+    );
+
+    const inspectorTab = screen.getByTestId('panel-tab-inspector');
+    expect(inspectorTab).toHaveAccessibleName('Inspector');
+    expect(inspectorTab).toHaveAttribute('aria-current', 'true');
+    expect(inspectorTab).toHaveAttribute('data-active', 'true');
+
+    fireEvent.click(screen.getByTestId('panel-tab-activity'));
+    expect(screen.getByTestId('panel-tab-activity')).toHaveAttribute('aria-current', 'true');
+  });
+
   it('inactive tab does not have aria-current', () => {
     render(
       <Wrapper mode="panel" activeView="inspector">

--- a/src/shell/right-panel.tsx
+++ b/src/shell/right-panel.tsx
@@ -17,7 +17,8 @@
  */
 
 import { Maximize2, Minimize2, X } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+import { Fragment, useEffect, useRef, useState } from 'react';
 import { cn } from '../lib/utils.js';
 import { useResolvedPanelViews } from './panel-views-provider.js';
 import { useMedaShell } from './shell-provider.js';
@@ -47,8 +48,20 @@ export interface RightPanelProps {
    * If only ['panel'], the cycle button is hidden.
    */
   modes?: PanelMode[];
+  renderTab?: (args: RightPanelTabRenderArgs) => ReactNode;
   className?: string;
 }
+
+export interface RightPanelTabRenderArgs {
+  view: PanelView;
+  isActive: boolean;
+  buttonProps: RightPanelTabButtonProps;
+  children: ReactNode;
+}
+
+export type RightPanelTabButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  'data-active'?: boolean;
+};
 
 // ---------------------------------------------------------------------------
 // ResizeHandle — left-edge drag handle (Pattern B)
@@ -121,6 +134,7 @@ export function RightPanel({
   panelViews = EMPTY_PANEL_VIEWS,
   defaultView,
   modes = ['panel', 'expanded', 'fullscreen'],
+  renderTab,
   className,
 }: RightPanelProps) {
   const band = useShellViewport();
@@ -225,23 +239,35 @@ export function RightPanel({
               {resolvedPanelViews.map((view) => {
                 const isActive = view.id === activeView;
                 const Icon = view.icon;
-                return (
-                  <button
-                    key={view.id}
-                    type="button"
-                    aria-current={isActive ? 'true' : undefined}
-                    onClick={() => setActiveView(view.id)}
-                    className={cn(
-                      'inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium transition-colors',
-                      isActive
-                        ? 'bg-accent text-accent-foreground'
-                        : 'text-muted-foreground hover:bg-accent hover:text-foreground'
-                    )}
-                  >
+                const children = (
+                  <>
                     <Icon size={14} aria-hidden="true" />
                     <span>{view.label}</span>
-                  </button>
+                  </>
                 );
+                const buttonProps = {
+                  type: 'button',
+                  'aria-current': isActive ? 'true' : undefined,
+                  'data-active': isActive || undefined,
+                  onClick: () => setActiveView(view.id),
+                  className: cn(
+                    'inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium transition-colors',
+                    isActive
+                      ? 'bg-accent text-accent-foreground'
+                      : 'text-muted-foreground hover:bg-accent hover:text-foreground'
+                  ),
+                  children,
+                } satisfies RightPanelTabButtonProps;
+
+                if (renderTab) {
+                  return (
+                    <Fragment key={view.id}>
+                      {renderTab({ view, isActive, buttonProps, children })}
+                    </Fragment>
+                  );
+                }
+
+                return <button key={view.id} {...buttonProps} />;
               })}
             </div>
 

--- a/src/shell/types.ts
+++ b/src/shell/types.ts
@@ -1,6 +1,6 @@
 'use client';
 import type { LucideIcon } from 'lucide-react';
-import type { ReactNode } from 'react';
+import type { AnchorHTMLAttributes, ReactNode } from 'react';
 
 export interface AppDefinition {
   id: string;
@@ -64,6 +64,7 @@ export interface ShellLinkRenderArgs {
   isActive: boolean;
   className: string;
   children: ReactNode;
+  linkProps: AnchorHTMLAttributes<HTMLAnchorElement>;
 }
 
 export interface CommandDefinition {


### PR DESCRIPTION
## Summary
- add a shared render-element helper for boundary components that composes consumer and Meda event handlers
- let `AuthProviderButton` render through a custom element while preserving loading, disabled, ARIA, data attributes, and children
- pass default link props through `IconRail`/`ContextRail` render adapters, including mobile menu links
- add custom right-panel tab rendering with Meda tab props preserved

## Verification
- `pnpm typecheck`
- `pnpm build`
- `pnpm exec vitest run --environment jsdom src/auth/auth-provider-button.test.tsx src/shell/icon-rail.test.tsx src/shell/context-rail.test.tsx src/shell/right-panel.test.tsx src/shell/app-shell-workspace.test.tsx`
- `pnpm test`

Stacked on #73 (`feat/auth-adoption-controls`) so the PR only shows the render-boundary layer once #73 is reviewed and merged.
