### PR TITLE
Package split and Next recipes

### DIFF
--- a/.changeset/meda-package-recipes.md
+++ b/.changeset/meda-package-recipes.md
@@ -1,0 +1,5 @@
+---
+"@medalsocial/meda": minor
+---
+
+Add shell primitive and Next recipe package subpaths, plus registry metadata for copyable AppShell adoption recipes.

--- a/dist/recipes/next.d.ts
+++ b/dist/recipes/next.d.ts
@@ -1,0 +1,46 @@
+export interface MedaRecipeFile {
+    path: string;
+    target: string;
+    type: 'registry:block' | 'registry:component' | 'registry:hook' | 'registry:lib';
+    content: string;
+}
+export interface MedaRecipe {
+    name: string;
+    title: string;
+    description: string;
+    dependencies: string[];
+    peerDependencies: string[];
+    cssVars: string[];
+    files: MedaRecipeFile[];
+    accessibility: string[];
+}
+export declare const nextAppShellRecipe: {
+    name: string;
+    title: string;
+    description: string;
+    dependencies: string[];
+    peerDependencies: string[];
+    cssVars: string[];
+    files: {
+        path: string;
+        target: string;
+        type: "registry:block";
+        content: string;
+    }[];
+    accessibility: string[];
+};
+export declare const nextRecipes: {
+    name: string;
+    title: string;
+    description: string;
+    dependencies: string[];
+    peerDependencies: string[];
+    cssVars: string[];
+    files: {
+        path: string;
+        target: string;
+        type: "registry:block";
+        content: string;
+    }[];
+    accessibility: string[];
+}[];

--- a/dist/recipes/next.js
+++ b/dist/recipes/next.js
@@ -1,0 +1,122 @@
+export const nextAppShellRecipe = {
+    name: 'meda-next-app-shell',
+    title: 'Meda Next AppShell',
+    description: 'Copyable Next.js App Router shell adapter with next/link routing, route-owned panel views, and auth controls.',
+    dependencies: ['@medalsocial/meda', 'lucide-react'],
+    peerDependencies: ['next', 'react', 'react-dom'],
+    cssVars: ['@medalsocial/meda/styles.css'],
+    files: [
+        {
+            path: 'registry/meda/meda-next-app-shell/meda-next-app-shell.tsx',
+            target: 'components/meda/meda-next-app-shell.tsx',
+            type: 'registry:block',
+            content: `\
+'use client'
+
+import Link from 'next/link'
+import type { ComponentProps, ReactNode } from 'react'
+import {
+  AppShell,
+  AuthError,
+  AuthNotice,
+  AuthOneTapSlot,
+  AuthProviderButton,
+  AuthProviderList,
+  MedaShellProvider,
+  PanelViewsProvider,
+  type AppDefinition,
+  type IconRailItem,
+  type PanelView,
+  type WorkspaceDefinition,
+} from '@medalsocial/meda/shell'
+
+export function MedaNextWorkspaceShell({
+  workspace,
+  apps,
+  iconItems,
+  activeIconId,
+  panelViews = [],
+  defaultPanelView,
+  children,
+}: {
+  workspace: WorkspaceDefinition
+  apps: AppDefinition[]
+  iconItems: IconRailItem[]
+  activeIconId?: string
+  panelViews?: PanelView[]
+  defaultPanelView?: string
+  children: ReactNode
+}) {
+  return (
+    <MedaShellProvider workspace={workspace} apps={apps}>
+      <AppShell
+        variant="workspace"
+        iconRail={{
+          mainItems: iconItems,
+          activeId: activeIconId,
+          renderLink: ({ item, linkProps }) => (
+            <Link {...linkProps} href={item.to} prefetch />
+          ),
+        }}
+        rightPanel={{ panelViews, defaultView: defaultPanelView }}
+      >
+        <PanelViewsProvider views={panelViews} defaultView={defaultPanelView}>
+          {children}
+        </PanelViewsProvider>
+      </AppShell>
+    </MedaShellProvider>
+  )
+}
+
+export function MedaNextAuthShell({
+  brandName,
+  brandMark,
+  appName,
+  tagline,
+  preview,
+  error,
+  notice,
+  onGoogleSignIn,
+}: {
+  brandName: ReactNode
+  brandMark?: ReactNode
+  appName?: ReactNode
+  tagline?: ReactNode
+  preview?: ReactNode
+  error?: ReactNode
+  notice?: ReactNode
+  onGoogleSignIn: ComponentProps<typeof AuthProviderButton>['onClick']
+}) {
+  return (
+    <MedaShellProvider workspace={{ id: 'auth', name: 'Auth', icon: brandMark }} apps={[]}>
+      <AppShell
+        variant="auth"
+        branding={{ brandName, brandMark, appName, tagline }}
+        preview={preview}
+      >
+        <AuthProviderList>
+          <AuthProviderButton
+            provider="google"
+            label="Continue with Google"
+            onClick={onGoogleSignIn}
+          />
+        </AuthProviderList>
+        <AuthNotice>{notice}</AuthNotice>
+        <AuthError>{error}</AuthError>
+        <AuthOneTapSlot />
+      </AppShell>
+    </MedaShellProvider>
+  )
+}
+`,
+        },
+    ],
+    accessibility: [
+        'Every drawer and panel keeps its accessible name from AppShell and RightPanel.',
+        'Custom link renderers must forward all linkProps to preserve aria-current, labels, handlers, and className.',
+        'Auth provider buttons keep the visible provider affordance separate from the accessible button name.',
+        'Route-owned panel views should expose headings inside their rendered panel content.',
+        'Reduced-motion behavior remains delegated to Meda shell motion tokens.',
+    ],
+};
+export const nextRecipes = [nextAppShellRecipe];

--- a/dist/shell/index.d.ts
+++ b/dist/shell/index.d.ts
@@ -7,6 +7,7 @@ export { ContextRail } from './context-rail.js';
 export type { DragModeBannerProps } from './drag-mode-banner.js';
 export { DragModeBanner } from './drag-mode-banner.js';
 export * as Extras from './extras/index.js';
+export type { IconRailItem, IconRailProps, IconRailRenderLinkArgs } from './icon-rail.js';
 export { IconRail, RailDivider } from './icon-rail.js';
 export type { ShellStorageAdapter } from './layout-state.js';
 export { createLocalStorageAdapter } from './layout-state.js';

--- a/dist/shell/index.js
+++ b/dist/shell/index.js
@@ -13,7 +13,6 @@ export { ContextRail } from './context-rail.js';
 export { DragModeBanner } from './drag-mode-banner.js';
 // Extras (legacy components ported during Phase 15 — opt-in for apps that need them)
 export * as Extras from './extras/index.js';
-// Rails + main + panel
 export { IconRail, RailDivider } from './icon-rail.js';
 // Storage adapter (consumers may want to provide their own)
 export { createLocalStorageAdapter } from './layout-state.js';

--- a/dist/shell/primitives.d.ts
+++ b/dist/shell/primitives.d.ts
@@ -1,0 +1,9 @@
+export type { ShellStorageAdapter } from './layout-state.js';
+export { createLocalStorageAdapter } from './layout-state.js';
+export type { PanelViewsProviderProps } from './panel-views-provider.js';
+export { PanelViewsProvider } from './panel-views-provider.js';
+export { ResizableHandle, ResizableShell, ResizableShellPanel } from './resizable-shell.js';
+export type { MedaShellProviderProps } from './shell-provider.js';
+export { MedaShellProvider, useMedaShell, useShellSelection } from './shell-provider.js';
+export type { AppDefinition, CommandDefinition, ContextItem, ContextModule, MobileBottomNavItem, PanelMode, PanelView, ShellLinkRenderArgs, ShellRenderContext, ShellViewport, ThemeAdapter, WorkspaceDefinition, } from './types.js';
+export { useShellViewport } from './use-shell-viewport.js';

--- a/dist/shell/primitives.js
+++ b/dist/shell/primitives.js
@@ -1,0 +1,7 @@
+// State and layout primitives for consumers that want Meda shell behavior
+// without importing the full styled shell barrel.
+export { createLocalStorageAdapter } from './layout-state.js';
+export { PanelViewsProvider } from './panel-views-provider.js';
+export { ResizableHandle, ResizableShell, ResizableShellPanel } from './resizable-shell.js';
+export { MedaShellProvider, useMedaShell, useShellSelection } from './shell-provider.js';
+export { useShellViewport } from './use-shell-viewport.js';

--- a/package.json
+++ b/package.json
@@ -80,6 +80,14 @@
     },
     "./styles/tokens": {
       "default": "./dist/styles/tokens.css"
+    },
+    "./shell/primitives": {
+      "types": "./dist/shell/primitives.d.ts",
+      "default": "./dist/shell/primitives.js"
+    },
+    "./recipes/next": {
+      "types": "./dist/recipes/next.d.ts",
+      "default": "./dist/recipes/next.js"
     }
   },
   "sideEffects": [

--- a/registry/README.md
+++ b/registry/README.md
@@ -11,6 +11,7 @@ Current items:
 - `meda-shell`
 - `meda-shell-state`
 - `meda-workbench-layout`
+- `meda-next-app-shell`
 - `meda-marketing`
 - `meda-marketing-callout`
 - `meda-marketing-contact`

--- a/registry/r/meda-next-app-shell.json
+++ b/registry/r/meda-next-app-shell.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "meda-next-app-shell",
+  "type": "registry:block",
+  "title": "Meda Next AppShell",
+  "description": "Install a copyable Next.js App Router shell adapter with next/link routing, route-owned panel views, and auth controls.",
+  "dependencies": ["@medalsocial/meda", "lucide-react"],
+  "files": [
+    {
+      "path": "registry/meda/meda-next-app-shell/meda-next-app-shell.tsx",
+      "content": "export { nextAppShellRecipe as medaNextAppShellRecipe } from '@medalsocial/meda/recipes/next'\n",
+      "type": "registry:block",
+      "target": "components/meda/meda-next-app-shell.tsx"
+    }
+  ],
+  "meta": {
+    "peerDependencies": ["next", "react", "react-dom"],
+    "cssVars": ["@medalsocial/meda/styles.css"],
+    "accessibility": [
+      "Forward all linkProps from rail render callbacks.",
+      "Panel views should include a visible or visually-hidden heading.",
+      "Auth provider buttons preserve accessible button names."
+    ]
+  }
+}

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -50,6 +50,21 @@
     },
     {
       "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+      "name": "meda-next-app-shell",
+      "type": "registry:block",
+      "title": "Meda Next AppShell",
+      "description": "Install a copyable Next.js App Router shell adapter.",
+      "dependencies": ["@medalsocial/meda", "lucide-react"],
+      "files": [
+        {
+          "path": "registry/meda/meda-next-app-shell/meda-next-app-shell.tsx",
+          "type": "registry:block",
+          "target": "components/meda/meda-next-app-shell.tsx"
+        }
+      ]
+    },
+    {
+      "$schema": "https://ui.shadcn.com/schema/registry-item.json",
       "name": "meda-marketing",
       "type": "registry:block",
       "title": "Meda Marketing",

--- a/registry/scripts/validate-registry.mjs
+++ b/registry/scripts/validate-registry.mjs
@@ -10,6 +10,7 @@ const files = [
   'r/meda-shell.json',
   'r/meda-shell-state.json',
   'r/meda-workbench-layout.json',
+  'r/meda-next-app-shell.json',
   'r/meda-marketing.json',
   'r/meda-marketing-callout.json',
   'r/meda-marketing-contact.json',
@@ -44,6 +45,15 @@ for (const [file, json] of parsedFiles.entries()) {
     `${file} must include a registry type.`
   );
   assert(Array.isArray(json?.dependencies), `${file} must declare dependencies.`);
+  if (json.meta?.peerDependencies) {
+    assert(Array.isArray(json.meta.peerDependencies), `${file} peerDependencies must be an array.`);
+  }
+  if (json.meta?.accessibility) {
+    assert(
+      Array.isArray(json.meta.accessibility) && json.meta.accessibility.length > 0,
+      `${file} accessibility metadata must be a non-empty array.`
+    );
+  }
   assert(
     Array.isArray(json?.files) && json.files.length > 0,
     `${file} must include at least one file entry.`

--- a/src/recipes/next.test.ts
+++ b/src/recipes/next.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { nextAppShellRecipe, nextRecipes } from './next.js';
+
+describe('Next recipes', () => {
+  it('publishes copyable Next AppShell recipe metadata', () => {
+    expect(nextRecipes).toContain(nextAppShellRecipe);
+    expect(nextAppShellRecipe.name).toBe('meda-next-app-shell');
+    expect(nextAppShellRecipe.dependencies).toContain('@medalsocial/meda');
+    expect(nextAppShellRecipe.peerDependencies).toEqual(
+      expect.arrayContaining(['next', 'react', 'react-dom'])
+    );
+    expect(nextAppShellRecipe.files[0]?.content).toContain('next/link');
+  });
+
+  it('passes route panel views to AppShell on first render', () => {
+    expect(nextAppShellRecipe.files[0]?.content).toContain(
+      'rightPanel={{ panelViews, defaultView: defaultPanelView }}'
+    );
+    expect(nextAppShellRecipe.files[0]?.content).not.toContain('panelViews: []');
+  });
+
+  it('documents accessibility and composition contracts', () => {
+    expect(nextAppShellRecipe.accessibility).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('linkProps'),
+        expect.stringContaining('Auth provider buttons'),
+      ])
+    );
+  });
+});

--- a/src/recipes/next.ts
+++ b/src/recipes/next.ts
@@ -1,0 +1,142 @@
+export interface MedaRecipeFile {
+  path: string;
+  target: string;
+  type: 'registry:block' | 'registry:component' | 'registry:hook' | 'registry:lib';
+  content: string;
+}
+
+export interface MedaRecipe {
+  name: string;
+  title: string;
+  description: string;
+  dependencies: string[];
+  peerDependencies: string[];
+  cssVars: string[];
+  files: MedaRecipeFile[];
+  accessibility: string[];
+}
+
+export const nextAppShellRecipe = {
+  name: 'meda-next-app-shell',
+  title: 'Meda Next AppShell',
+  description:
+    'Copyable Next.js App Router shell adapter with next/link routing, route-owned panel views, and auth controls.',
+  dependencies: ['@medalsocial/meda', 'lucide-react'],
+  peerDependencies: ['next', 'react', 'react-dom'],
+  cssVars: ['@medalsocial/meda/styles.css'],
+  files: [
+    {
+      path: 'registry/meda/meda-next-app-shell/meda-next-app-shell.tsx',
+      target: 'components/meda/meda-next-app-shell.tsx',
+      type: 'registry:block',
+      content: `\
+'use client'
+
+import Link from 'next/link'
+import type { ComponentProps, ReactNode } from 'react'
+import {
+  AppShell,
+  AuthError,
+  AuthNotice,
+  AuthOneTapSlot,
+  AuthProviderButton,
+  AuthProviderList,
+  MedaShellProvider,
+  PanelViewsProvider,
+  type AppDefinition,
+  type IconRailItem,
+  type PanelView,
+  type WorkspaceDefinition,
+} from '@medalsocial/meda/shell'
+
+export function MedaNextWorkspaceShell({
+  workspace,
+  apps,
+  iconItems,
+  activeIconId,
+  panelViews = [],
+  defaultPanelView,
+  children,
+}: {
+  workspace: WorkspaceDefinition
+  apps: AppDefinition[]
+  iconItems: IconRailItem[]
+  activeIconId?: string
+  panelViews?: PanelView[]
+  defaultPanelView?: string
+  children: ReactNode
+}) {
+  return (
+    <MedaShellProvider workspace={workspace} apps={apps}>
+      <AppShell
+        variant="workspace"
+        iconRail={{
+          mainItems: iconItems,
+          activeId: activeIconId,
+          renderLink: ({ item, linkProps }) => (
+            <Link {...linkProps} href={item.to} prefetch />
+          ),
+        }}
+        rightPanel={{ panelViews, defaultView: defaultPanelView }}
+      >
+        <PanelViewsProvider views={panelViews} defaultView={defaultPanelView}>
+          {children}
+        </PanelViewsProvider>
+      </AppShell>
+    </MedaShellProvider>
+  )
+}
+
+export function MedaNextAuthShell({
+  brandName,
+  brandMark,
+  appName,
+  tagline,
+  preview,
+  error,
+  notice,
+  onGoogleSignIn,
+}: {
+  brandName: ReactNode
+  brandMark?: ReactNode
+  appName?: ReactNode
+  tagline?: ReactNode
+  preview?: ReactNode
+  error?: ReactNode
+  notice?: ReactNode
+  onGoogleSignIn: ComponentProps<typeof AuthProviderButton>['onClick']
+}) {
+  return (
+    <MedaShellProvider workspace={{ id: 'auth', name: 'Auth', icon: brandMark }} apps={[]}>
+      <AppShell
+        variant="auth"
+        branding={{ brandName, brandMark, appName, tagline }}
+        preview={preview}
+      >
+        <AuthProviderList>
+          <AuthProviderButton
+            provider="google"
+            label="Continue with Google"
+            onClick={onGoogleSignIn}
+          />
+        </AuthProviderList>
+        <AuthNotice>{notice}</AuthNotice>
+        <AuthError>{error}</AuthError>
+        <AuthOneTapSlot />
+      </AppShell>
+    </MedaShellProvider>
+  )
+}
+`,
+    },
+  ],
+  accessibility: [
+    'Every drawer and panel keeps its accessible name from AppShell and RightPanel.',
+    'Custom link renderers must forward all linkProps to preserve aria-current, labels, handlers, and className.',
+    'Auth provider buttons keep the visible provider affordance separate from the accessible button name.',
+    'Route-owned panel views should expose headings inside their rendered panel content.',
+    'Reduced-motion behavior remains delegated to Meda shell motion tokens.',
+  ],
+} satisfies MedaRecipe;
+
+export const nextRecipes = [nextAppShellRecipe] satisfies MedaRecipe[];

--- a/src/shell/index.ts
+++ b/src/shell/index.ts
@@ -30,6 +30,7 @@ export { DragModeBanner } from './drag-mode-banner.js';
 // Extras (legacy components ported during Phase 15 — opt-in for apps that need them)
 export * as Extras from './extras/index.js';
 // Rails + main + panel
+export type { IconRailItem, IconRailProps, IconRailRenderLinkArgs } from './icon-rail.js';
 export { IconRail, RailDivider } from './icon-rail.js';
 export type { ShellStorageAdapter } from './layout-state.js';
 // Storage adapter (consumers may want to provide their own)

--- a/src/shell/primitives.ts
+++ b/src/shell/primitives.ts
@@ -1,0 +1,25 @@
+// State and layout primitives for consumers that want Meda shell behavior
+// without importing the full styled shell barrel.
+
+export type { ShellStorageAdapter } from './layout-state.js';
+export { createLocalStorageAdapter } from './layout-state.js';
+export type { PanelViewsProviderProps } from './panel-views-provider.js';
+export { PanelViewsProvider } from './panel-views-provider.js';
+export { ResizableHandle, ResizableShell, ResizableShellPanel } from './resizable-shell.js';
+export type { MedaShellProviderProps } from './shell-provider.js';
+export { MedaShellProvider, useMedaShell, useShellSelection } from './shell-provider.js';
+export type {
+  AppDefinition,
+  CommandDefinition,
+  ContextItem,
+  ContextModule,
+  MobileBottomNavItem,
+  PanelMode,
+  PanelView,
+  ShellLinkRenderArgs,
+  ShellRenderContext,
+  ShellViewport,
+  ThemeAdapter,
+  WorkspaceDefinition,
+} from './types.js';
+export { useShellViewport } from './use-shell-viewport.js';


### PR DESCRIPTION
## Summary
- add `@medalsocial/meda/shell/primitives` for shell state, layout, provider, and viewport primitives
- add `@medalsocial/meda/recipes/next` with typed Next AppShell recipe metadata
- add a `meda-next-app-shell` registry item with peer dependency and accessibility metadata
- export `IconRail` item/render types from the shell barrel for recipe adapters

## Verification
- `pnpm typecheck`
- `pnpm build`
- `pnpm exec vitest run --environment jsdom src/recipes/next.test.ts`
- `pnpm registry:validate`
- `pnpm test`

Stacked on #74 (`feat/render-prop-boundaries`) so this PR only shows the package/recipe layer once the render-boundary stack lands.
