### PR TITLE
Add Meda theme bridge contracts

### DIFF
--- a/.changeset/meda-theme-bridge-contracts.md
+++ b/.changeset/meda-theme-bridge-contracts.md
@@ -1,0 +1,5 @@
+---
+"@medalsocial/meda": minor
+---
+
+Add a public theme bridge helper for app-scoped Meda token CSS and strengthen Next recipe accessibility/composition contracts.

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -4,4 +4,5 @@ export * from './chat/public.js';
 export * from './marketing/public.js';
 export * from './panel/public.js';
 export * from './shell/index.js';
+export * from './theme/index.js';
 export * from './timeline/public.js';

--- a/dist/index.js
+++ b/dist/index.js
@@ -4,4 +4,5 @@ export * from './chat/public.js';
 export * from './marketing/public.js';
 export * from './panel/public.js';
 export * from './shell/index.js'; // v2 surface
+export * from './theme/index.js';
 export * from './timeline/public.js';

--- a/dist/recipes/next.d.ts
+++ b/dist/recipes/next.d.ts
@@ -13,6 +13,7 @@ export interface MedaRecipe {
     cssVars: string[];
     files: MedaRecipeFile[];
     accessibility: string[];
+    composition: string[];
 }
 export declare const nextAppShellRecipe: {
     name: string;
@@ -28,6 +29,7 @@ export declare const nextAppShellRecipe: {
         content: string;
     }[];
     accessibility: string[];
+    composition: string[];
 };
 export declare const nextRecipes: {
     name: string;
@@ -43,4 +45,5 @@ export declare const nextRecipes: {
         content: string;
     }[];
     accessibility: string[];
+    composition: string[];
 }[];

--- a/dist/recipes/next.js
+++ b/dist/recipes/next.js
@@ -118,5 +118,11 @@ export function MedaNextAuthShell({
         'Route-owned panel views should expose headings inside their rendered panel content.',
         'Reduced-motion behavior remains delegated to Meda shell motion tokens.',
     ],
+    composition: [
+        'MedaShellProvider owns workspace and app context for the copied shell adapter.',
+        'AppShell receives route-owned rightPanel views on first render to avoid delayed panel UI.',
+        'PanelViewsProvider wraps children with the same panelViews and defaultPanelView for nested route registrations.',
+        'renderLink composes Next Link by forwarding Meda linkProps before setting framework-specific props.',
+    ],
 };
 export const nextRecipes = [nextAppShellRecipe];

--- a/dist/theme/index.d.ts
+++ b/dist/theme/index.d.ts
@@ -1,0 +1,1 @@
+export { createMedaThemeCss, defineMedaTheme, type MedaThemeConfig, type MedaThemeDefinition, type MedaThemeMode, type MedaThemeModeConfig, type MedaThemeTokenMap, } from './theme-bridge.js';

--- a/dist/theme/index.js
+++ b/dist/theme/index.js
@@ -1,0 +1,1 @@
+export { createMedaThemeCss, defineMedaTheme, } from './theme-bridge.js';

--- a/dist/theme/theme-bridge.d.ts
+++ b/dist/theme/theme-bridge.d.ts
@@ -1,0 +1,21 @@
+export type MedaThemeMode = 'light' | 'dark';
+export type MedaThemeTokenMap = Record<string, string | undefined>;
+export interface MedaThemeModeConfig {
+    colors?: MedaThemeTokenMap;
+    fonts?: MedaThemeTokenMap;
+    tokens?: MedaThemeTokenMap;
+}
+export interface MedaThemeConfig extends MedaThemeModeConfig {
+    appId: string;
+    selector?: string;
+    light?: MedaThemeModeConfig;
+    dark?: MedaThemeModeConfig;
+}
+export interface MedaThemeDefinition {
+    appId: string;
+    selector: string;
+    light: Required<MedaThemeModeConfig>;
+    dark: Required<MedaThemeModeConfig>;
+}
+export declare function defineMedaTheme(config: MedaThemeConfig): MedaThemeDefinition;
+export declare function createMedaThemeCss(theme: MedaThemeDefinition): string;

--- a/dist/theme/theme-bridge.js
+++ b/dist/theme/theme-bridge.js
@@ -1,0 +1,52 @@
+const MODE_KEYS = ['colors', 'fonts', 'tokens'];
+function assertAppId(appId) {
+    if (!/^[a-zA-Z0-9_-]+$/.test(appId)) {
+        throw new Error('Meda theme appId must contain only letters, numbers, underscores, or dashes.');
+    }
+}
+function toCssVariableName(group, key) {
+    const normalized = key.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`);
+    if (normalized.startsWith('--')) {
+        return normalized;
+    }
+    if (group === 'fonts') {
+        return `--font-${normalized}`;
+    }
+    return `--${normalized}`;
+}
+function mergeModeConfig(base, mode = {}) {
+    return {
+        colors: { ...base.colors, ...mode.colors },
+        fonts: { ...base.fonts, ...mode.fonts },
+        tokens: { ...base.tokens, ...mode.tokens },
+    };
+}
+export function defineMedaTheme(config) {
+    assertAppId(config.appId);
+    const base = {
+        colors: config.colors ?? {},
+        fonts: config.fonts ?? {},
+        tokens: config.tokens ?? {},
+    };
+    return {
+        appId: config.appId,
+        selector: config.selector ?? `[data-meda-app="${config.appId}"]`,
+        light: mergeModeConfig(base, config.light),
+        dark: mergeModeConfig(base, config.dark),
+    };
+}
+function entriesForMode(mode) {
+    return MODE_KEYS.flatMap((group) => Object.entries(mode[group])
+        .filter((entry) => typeof entry[1] === 'string')
+        .map(([key, value]) => [toCssVariableName(group, key), value])).sort(([left], [right]) => left.localeCompare(right));
+}
+function renderBlock(selector, entries) {
+    const declarations = entries.map(([key, value]) => `  ${key}: ${value};`).join('\n');
+    return `${selector} {\n${declarations}\n}`;
+}
+export function createMedaThemeCss(theme) {
+    const lightEntries = entriesForMode(theme.light);
+    const darkEntries = entriesForMode(theme.dark);
+    const darkSelector = `${theme.selector}.dark, ${theme.selector}[data-theme="dark"]`;
+    return [renderBlock(theme.selector, lightEntries), renderBlock(darkSelector, darkEntries)].join('\n\n');
+}

--- a/package.json
+++ b/package.json
@@ -88,6 +88,10 @@
     "./recipes/next": {
       "types": "./dist/recipes/next.d.ts",
       "default": "./dist/recipes/next.js"
+    },
+    "./theme": {
+      "types": "./dist/theme/index.d.ts",
+      "default": "./dist/theme/index.js"
     }
   },
   "sideEffects": [

--- a/registry/r/meda-next-app-shell.json
+++ b/registry/r/meda-next-app-shell.json
@@ -20,6 +20,12 @@
       "Forward all linkProps from rail render callbacks.",
       "Panel views should include a visible or visually-hidden heading.",
       "Auth provider buttons preserve accessible button names."
+    ],
+    "composition": [
+      "MedaShellProvider owns workspace/app context.",
+      "AppShell receives rightPanel views on first render.",
+      "PanelViewsProvider keeps route-owned panel registrations available to nested content.",
+      "Next Link adapters forward Meda linkProps before adding framework-specific props."
     ]
   }
 }

--- a/registry/scripts/validate-registry.mjs
+++ b/registry/scripts/validate-registry.mjs
@@ -23,6 +23,13 @@ function assert(condition, message) {
   }
 }
 
+function assertStringList(value, label) {
+  assert(Array.isArray(value) && value.length > 0, `${label} must be a non-empty array.`);
+  for (const item of value) {
+    assert(typeof item === 'string' && item.trim().length > 0, `${label} must contain strings.`);
+  }
+}
+
 const parsedFiles = new Map();
 
 for (const file of files) {
@@ -46,13 +53,17 @@ for (const [file, json] of parsedFiles.entries()) {
   );
   assert(Array.isArray(json?.dependencies), `${file} must declare dependencies.`);
   if (json.meta?.peerDependencies) {
-    assert(Array.isArray(json.meta.peerDependencies), `${file} peerDependencies must be an array.`);
+    assertStringList(json.meta.peerDependencies, `${file} peerDependencies`);
   }
   if (json.meta?.accessibility) {
-    assert(
-      Array.isArray(json.meta.accessibility) && json.meta.accessibility.length > 0,
-      `${file} accessibility metadata must be a non-empty array.`
-    );
+    assertStringList(json.meta.accessibility, `${file} accessibility metadata`);
+  }
+  if (json.meta?.composition) {
+    assertStringList(json.meta.composition, `${file} composition metadata`);
+  }
+  if (file === 'r/meda-next-app-shell.json') {
+    assertStringList(json.meta?.accessibility, `${file} accessibility metadata`);
+    assertStringList(json.meta?.composition, `${file} composition metadata`);
   }
   assert(
     Array.isArray(json?.files) && json.files.length > 0,

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,5 @@ export * from './chat/public.js';
 export * from './marketing/public.js';
 export * from './panel/public.js';
 export * from './shell/index.js'; // v2 surface
+export * from './theme/index.js';
 export * from './timeline/public.js';

--- a/src/recipes/next.test.ts
+++ b/src/recipes/next.test.ts
@@ -20,10 +20,24 @@ describe('Next recipes', () => {
   });
 
   it('documents accessibility and composition contracts', () => {
+    expect(nextAppShellRecipe.accessibility.length).toBeGreaterThan(0);
+    expect(nextAppShellRecipe.composition.length).toBeGreaterThan(0);
     expect(nextAppShellRecipe.accessibility).toEqual(
       expect.arrayContaining([
         expect.stringContaining('linkProps'),
+        expect.stringContaining('aria-current'),
         expect.stringContaining('Auth provider buttons'),
+        expect.stringContaining('headings'),
+        expect.stringContaining('Reduced-motion'),
+      ])
+    );
+    expect(nextAppShellRecipe.composition).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('MedaShellProvider'),
+        expect.stringContaining('AppShell'),
+        expect.stringContaining('rightPanel'),
+        expect.stringContaining('PanelViewsProvider'),
+        expect.stringContaining('renderLink'),
       ])
     );
   });

--- a/src/recipes/next.ts
+++ b/src/recipes/next.ts
@@ -14,6 +14,7 @@ export interface MedaRecipe {
   cssVars: string[];
   files: MedaRecipeFile[];
   accessibility: string[];
+  composition: string[];
 }
 
 export const nextAppShellRecipe = {
@@ -136,6 +137,12 @@ export function MedaNextAuthShell({
     'Auth provider buttons keep the visible provider affordance separate from the accessible button name.',
     'Route-owned panel views should expose headings inside their rendered panel content.',
     'Reduced-motion behavior remains delegated to Meda shell motion tokens.',
+  ],
+  composition: [
+    'MedaShellProvider owns workspace and app context for the copied shell adapter.',
+    'AppShell receives route-owned rightPanel views on first render to avoid delayed panel UI.',
+    'PanelViewsProvider wraps children with the same panelViews and defaultPanelView for nested route registrations.',
+    'renderLink composes Next Link by forwarding Meda linkProps before setting framework-specific props.',
   ],
 } satisfies MedaRecipe;
 

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,0 +1,9 @@
+export {
+  createMedaThemeCss,
+  defineMedaTheme,
+  type MedaThemeConfig,
+  type MedaThemeDefinition,
+  type MedaThemeMode,
+  type MedaThemeModeConfig,
+  type MedaThemeTokenMap,
+} from './theme-bridge.js';

--- a/src/theme/theme-bridge.test.ts
+++ b/src/theme/theme-bridge.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { createMedaThemeCss, defineMedaTheme } from './theme-bridge.js';
+
+describe('Meda theme bridge', () => {
+  it('generates light and dark app-scoped token CSS', () => {
+    const theme = defineMedaTheme({
+      appId: 'auto',
+      colors: {
+        primary: 'var(--hb-brand-500)',
+      },
+      fonts: {
+        body: 'var(--font-body)',
+      },
+      light: {
+        colors: {
+          background: 'var(--hb-base-50)',
+          foreground: 'var(--hb-base-950)',
+        },
+      },
+      dark: {
+        colors: {
+          background: 'var(--hb-base-900)',
+          foreground: 'var(--hb-base-50)',
+        },
+      },
+    });
+
+    expect(createMedaThemeCss(theme)).toMatchInlineSnapshot(`
+      "[data-meda-app="auto"] {
+        --background: var(--hb-base-50);
+        --font-body: var(--font-body);
+        --foreground: var(--hb-base-950);
+        --primary: var(--hb-brand-500);
+      }
+
+      [data-meda-app="auto"].dark, [data-meda-app="auto"][data-theme="dark"] {
+        --background: var(--hb-base-900);
+        --font-body: var(--font-body);
+        --foreground: var(--hb-base-50);
+        --primary: var(--hb-brand-500);
+      }"
+    `);
+  });
+
+  it('rejects app ids that cannot be safely embedded in selectors', () => {
+    expect(() => defineMedaTheme({ appId: 'auto app' })).toThrow(
+      'Meda theme appId must contain only letters, numbers, underscores, or dashes.'
+    );
+  });
+});

--- a/src/theme/theme-bridge.ts
+++ b/src/theme/theme-bridge.ts
@@ -1,0 +1,89 @@
+export type MedaThemeMode = 'light' | 'dark';
+
+export type MedaThemeTokenMap = Record<string, string | undefined>;
+
+export interface MedaThemeModeConfig {
+  colors?: MedaThemeTokenMap;
+  fonts?: MedaThemeTokenMap;
+  tokens?: MedaThemeTokenMap;
+}
+
+export interface MedaThemeConfig extends MedaThemeModeConfig {
+  appId: string;
+  selector?: string;
+  light?: MedaThemeModeConfig;
+  dark?: MedaThemeModeConfig;
+}
+
+export interface MedaThemeDefinition {
+  appId: string;
+  selector: string;
+  light: Required<MedaThemeModeConfig>;
+  dark: Required<MedaThemeModeConfig>;
+}
+
+const MODE_KEYS = ['colors', 'fonts', 'tokens'] as const;
+
+function assertAppId(appId: string) {
+  if (!/^[a-zA-Z0-9_-]+$/.test(appId)) {
+    throw new Error('Meda theme appId must contain only letters, numbers, underscores, or dashes.');
+  }
+}
+
+function toCssVariableName(group: (typeof MODE_KEYS)[number], key: string) {
+  const normalized = key.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`);
+  if (normalized.startsWith('--')) {
+    return normalized;
+  }
+  if (group === 'fonts') {
+    return `--font-${normalized}`;
+  }
+  return `--${normalized}`;
+}
+
+function mergeModeConfig(base: MedaThemeModeConfig, mode: MedaThemeModeConfig = {}) {
+  return {
+    colors: { ...base.colors, ...mode.colors },
+    fonts: { ...base.fonts, ...mode.fonts },
+    tokens: { ...base.tokens, ...mode.tokens },
+  };
+}
+
+export function defineMedaTheme(config: MedaThemeConfig): MedaThemeDefinition {
+  assertAppId(config.appId);
+  const base = {
+    colors: config.colors ?? {},
+    fonts: config.fonts ?? {},
+    tokens: config.tokens ?? {},
+  };
+
+  return {
+    appId: config.appId,
+    selector: config.selector ?? `[data-meda-app="${config.appId}"]`,
+    light: mergeModeConfig(base, config.light),
+    dark: mergeModeConfig(base, config.dark),
+  };
+}
+
+function entriesForMode(mode: Required<MedaThemeModeConfig>) {
+  return MODE_KEYS.flatMap((group) =>
+    Object.entries(mode[group])
+      .filter((entry): entry is [string, string] => typeof entry[1] === 'string')
+      .map(([key, value]) => [toCssVariableName(group, key), value] as const)
+  ).sort(([left], [right]) => left.localeCompare(right));
+}
+
+function renderBlock(selector: string, entries: ReadonlyArray<readonly [string, string]>) {
+  const declarations = entries.map(([key, value]) => `  ${key}: ${value};`).join('\n');
+  return `${selector} {\n${declarations}\n}`;
+}
+
+export function createMedaThemeCss(theme: MedaThemeDefinition) {
+  const lightEntries = entriesForMode(theme.light);
+  const darkEntries = entriesForMode(theme.dark);
+  const darkSelector = `${theme.selector}.dark, ${theme.selector}[data-theme="dark"]`;
+
+  return [renderBlock(theme.selector, lightEntries), renderBlock(darkSelector, darkEntries)].join(
+    '\n\n'
+  );
+}


### PR DESCRIPTION
## Summary
- add @medalsocial/meda/theme with defineMedaTheme and createMedaThemeCss for app-scoped token bridges
- strengthen Next recipe accessibility and composition metadata
- validate recipe composition metadata in the registry checker

## Verification
- pnpm exec vitest run --environment jsdom src/theme/theme-bridge.test.ts src/recipes/next.test.ts
- pnpm build
- pnpm typecheck
- pnpm registry:validate
- pnpm lint (passes with existing warnings)
- pnpm test
- pnpm check:stories (existing app-shell story soft-cap warning)
- node package-export smoke check for ./dist/theme/index.js