### PR TITLE
Finalize Meda adoption docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # @medalsocial/meda
 
-Shared UI shell and runtime primitives — the navigation chrome, panels, tab bars, command palette, and workbench layout that power Medal's apps. Published as Apache-2.0.
+Shared UI shell and runtime primitives — the navigation chrome, panels, auth controls, recipes, theme bridges, command palette, and workbench layout that power Medal's apps. Published as Apache-2.0.
 
 ![npm](https://img.shields.io/npm/v/@medalsocial/meda)
 
 ## Install
 
 ```bash
-pnpm add @medalsocial/meda
+pnpm add @medalsocial/meda lucide-react
 ```
 
-Peer deps: `react >= 19`, `react-dom >= 19`.
+Peer deps: `react >= 19`, `react-dom >= 19`, and `lucide-react`.
 
 ## Tailwind CSS v4 setup
 
@@ -22,36 +22,81 @@ Meda ships a `styles.css` with its design tokens. Import it once in your entry s
 
 ## Usage
 
-`ShellStateProvider` stores panel/selection state in URL search params and is router-agnostic. You provide a `ShellSearchParamsAdapter` so it can read and update them however your router prefers. A minimal, in-memory adapter:
+Use `AppShell` for the styled shell surface:
 
 ```tsx
-import { useState } from 'react';
-import { ShellStateProvider, ShellFrame } from '@medalsocial/meda';
+import { AppShell, MedaShellProvider } from '@medalsocial/meda/shell';
+import { Inbox } from 'lucide-react';
 
 export function App() {
-  const [searchParams, setSearchParams] = useState(() => new URLSearchParams());
+  const workspace = { id: 'workspace', name: 'Workspace' };
+  const apps = [{ id: 'inbox', label: 'Inbox', icon: Inbox }];
 
   return (
-    <ShellStateProvider
-      adapter={{
-        searchParams,
-        setSearchParams: (updater) => setSearchParams((current) => updater(current)),
-      }}
-    >
-      <ShellFrame>{/* your app */}</ShellFrame>
-    </ShellStateProvider>
+    <MedaShellProvider workspace={workspace} apps={apps}>
+      <AppShell
+        variant="workspace"
+        iconRail={{
+          mainItems: [{ id: 'inbox', label: 'Inbox', icon: Inbox, to: '/inbox' }],
+        }}
+      >
+        {/* your app */}
+      </AppShell>
+    </MedaShellProvider>
   );
 }
 ```
 
-For a real app, wire the adapter to your router (e.g. TanStack Router's `useSearch`/`useNavigate`, React Router's `useSearchParams`) so URL changes persist state.
+For framework routing, pass a render callback and forward Meda props:
+
+```tsx
+import Link from 'next/link';
+
+<AppShell
+  variant="workspace"
+  iconRail={{
+    mainItems,
+    renderLink: ({ item, linkProps }) => <Link {...linkProps} href={item.to} prefetch />,
+  }}
+>
+  {children}
+</AppShell>;
+```
+
+For app-scoped brand tokens:
+
+```ts
+import { createMedaThemeCss, defineMedaTheme } from '@medalsocial/meda/theme';
+
+const css = createMedaThemeCss(
+  defineMedaTheme({
+    appId: 'auto',
+    colors: {
+      primary: 'var(--hb-brand-500)',
+      background: 'var(--hb-base-50)',
+    },
+    dark: {
+      colors: {
+        background: 'var(--hb-base-900)',
+      },
+    },
+  })
+);
+```
+
+Lower-level `ShellStateProvider` and layout parts remain available from `@medalsocial/meda/shell/primitives` for apps that need to own more composition.
 
 See the [demo app](./demo) for a live playground.
 
 ## Exports
 
 - `@medalsocial/meda` — curated public API (components + helpers)
-- `@medalsocial/meda/shell` — shell-only subpath
+- `@medalsocial/meda/shell` — styled shell components and hooks
+- `@medalsocial/meda/shell/primitives` — lower-level shell state and layout primitives
+- `@medalsocial/meda/auth` — provider-neutral auth controls
+- `@medalsocial/meda/auth/better-auth` — optional better-auth adapter
+- `@medalsocial/meda/recipes/next` — copyable Next.js adoption recipe metadata
+- `@medalsocial/meda/theme` — app-scoped token bridge helpers
 - `@medalsocial/meda/marketing` — marketing sections and campaign blocks
 - `@medalsocial/meda/styles.css` — design tokens + base styles
 
@@ -64,6 +109,7 @@ Prefer to copy source into your project instead of installing? The shadcn-compat
 npx shadcn add https://meda.medalsocial.com/r/meda-shell.json
 npx shadcn add https://meda.medalsocial.com/r/meda-shell-state.json
 npx shadcn add https://meda.medalsocial.com/r/meda-workbench-layout.json
+npx shadcn add https://meda.medalsocial.com/r/meda-next-app-shell.json
 ```
 
 The registry index is at `https://meda.medalsocial.com/registry.json`. Source JSON files live under [`./registry`](./registry) in this repo and are deployed as static assets via Cloudflare Workers — see `wrangler.toml` and `.github/workflows/deploy-worker.yml`.

--- a/docs/STORIES.md
+++ b/docs/STORIES.md
@@ -81,3 +81,14 @@ Consumers compose one `<AppShell>` with a config:
 ```
 
 The variant decides which chrome renders. The viewport decides whether desktop or mobile chrome is used internally. Consumers do not import `MobileHeader`, `MobileBottomNav`, or `MobileDrawers` directly. Those are no longer exported.
+
+## Adoption recipes
+
+Copyable recipes should document both accessibility and composition contracts. At minimum, recipes that wrap `AppShell` need to say which props must be forwarded (`linkProps`, trigger props, tab props), where accessible names/headings come from, and which provider owns shell state.
+
+Keep recipe stories and docs close to the consumer workflow:
+
+- show framework adapters like `next/link` through render callbacks, not by replacing Meda state;
+- pass initial `rightPanel.panelViews` synchronously when they are known at layout render time;
+- use `PanelViewsProvider` for nested route registrations that need cleanup on unmount;
+- include reduced-motion and keyboard behavior in the recipe notes.

--- a/src/__stories__/docs/Adoption.mdx
+++ b/src/__stories__/docs/Adoption.mdx
@@ -1,0 +1,88 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Get Started/Adoption" />
+
+# Adoption
+
+Meda's shell can be adopted at three layers:
+
+1. **Styled shell**: import `AppShell` and `MedaShellProvider` from `@medalsocial/meda/shell`.
+2. **Shell primitives**: import state providers and lower-level layout parts from `@medalsocial/meda/shell/primitives`.
+3. **Copyable recipes**: use `@medalsocial/meda/recipes/next` or the registry item when a host app needs local routing, analytics, or auth glue.
+
+## Next.js links
+
+Framework routers should preserve Meda's link props:
+
+```tsx
+import Link from 'next/link';
+import { AppShell } from '@medalsocial/meda/shell';
+
+<AppShell
+  variant="workspace"
+  iconRail={{
+    mainItems,
+    activeId,
+    renderLink: ({ item, linkProps }) => <Link {...linkProps} href={item.to} prefetch />,
+  }}
+>
+  {children}
+</AppShell>;
+```
+
+`linkProps` carries Meda's accessibility labels, active state, event handlers, and class names. Spread it before framework-specific props.
+
+## Route-owned panels
+
+When panel views are known at layout render time, pass them directly to `AppShell` so the right panel and mobile panel button exist on first paint:
+
+```tsx
+<AppShell variant="workspace" rightPanel={{ panelViews, defaultView: 'details' }}>
+  <PanelViewsProvider views={panelViews} defaultView="details">
+    {children}
+  </PanelViewsProvider>
+</AppShell>
+```
+
+Use `PanelViewsProvider` deeper in the tree when a route owns temporary views that should unregister on unmount.
+
+## Auth screens
+
+Use provider-neutral controls from `@medalsocial/meda/auth`, then wire sign-in behavior in the app:
+
+```tsx
+<AppShell
+  variant="auth"
+  branding={{ brandName: 'Housebets', brandMark, appName: 'Auto', tagline: 'by Housebets' }}
+>
+  <AuthProviderList>
+    <AuthProviderButton provider="google" label="Continue with Google" onClick={onGoogleSignIn} />
+  </AuthProviderList>
+  <AuthError>{error}</AuthError>
+</AppShell>
+```
+
+The optional `@medalsocial/meda/auth/better-auth` subpath provides `BetterAuthProviderButton`, `BetterAuthOneTap`, and `useBetterAuthLastLoginMethod` without coupling the base auth controls to better-auth.
+
+## Theme bridge
+
+Use `@medalsocial/meda/theme` to generate app-scoped CSS for brand token mapping:
+
+```ts
+const css = createMedaThemeCss(
+  defineMedaTheme({
+    appId: 'auto',
+    colors: {
+      primary: 'var(--hb-brand-500)',
+    },
+    dark: {
+      colors: {
+        background: 'var(--hb-base-900)',
+        foreground: 'var(--hb-base-50)',
+      },
+    },
+  })
+);
+```
+
+Mount the app root with `data-meda-app="auto"` and toggle `.dark` or `data-theme="dark"` on the same root.

--- a/src/__stories__/docs/GetStarted.mdx
+++ b/src/__stories__/docs/GetStarted.mdx
@@ -12,6 +12,7 @@ This Storybook is the canonical reference for components, tokens, and interactio
 
 - **Foundations**: colors, typography, spacing, radii, shadows, motion, z-index, iconography, and the Medal Social mark. Values are sourced from `src/styles/tokens.css`, which mirrors `00-design-system.lib.pen`.
 - **AppShell**: the canonical shell. One component, three variants — `workspace`, `auth`, `chat`. Mobile chrome is internal; viewport switch is automatic.
+- **Adoption APIs**: Next recipes, route-owned panel views, render boundaries, auth controls, and app-scoped theme bridges.
 - **Marketing**: callout, contact, and lead-magnet surfaces.
 - **Audio**: voice orb, level meter, and status pill.
 - **Studios**: Inspector and Timeline (seeds for upcoming Email, Workflow, Unifi, and Site studios).
@@ -19,8 +20,9 @@ This Storybook is the canonical reference for components, tokens, and interactio
 ## Where to start
 
 1. [Installation](?path=/docs/get-started-installation--docs): pull the package into a host app.
-2. [Theming](?path=/docs/get-started-theming--docs): wire up canonical tokens.
-3. [Foundations / Color](?path=/docs/foundations-color--docs): review the brand ramp and semantic mapping.
+2. [Adoption](?path=/docs/get-started-adoption--docs): wire AppShell into an existing app.
+3. [Theming](?path=/docs/get-started-theming--docs): wire up canonical tokens.
+4. [Foundations / Color](?path=/docs/foundations-color--docs): review the brand ramp and semantic mapping.
 
 ## Conventions
 

--- a/src/__stories__/docs/Installation.mdx
+++ b/src/__stories__/docs/Installation.mdx
@@ -12,7 +12,7 @@ Meda is published to npm as `@medalsocial/meda`. It supports React 19+ and ships
 pnpm add @medalsocial/meda lucide-react
 ```
 
-`lucide-react` is a peer dependency.
+`lucide-react`, `react`, and `react-dom` are peer dependencies. Install `next-themes` only when using the optional `themeAdapter="next-themes"` shell bridge.
 
 ## Import the runtime CSS
 
@@ -31,22 +31,25 @@ This pulls in:
 ## Use a component
 
 ```tsx
-import { AppShell, AppShellBody, MedaShellProvider, ShellHeader } from '@medalsocial/meda/shell';
-import { Inbox } from 'lucide-react';
+import { AppShell, MedaShellProvider } from '@medalsocial/meda/shell';
+import { Inbox, Settings } from 'lucide-react';
 
 const workspace = { id: 'workspace', name: 'Workspace' };
 const apps = [{ id: 'inbox', label: 'Inbox', icon: Inbox }];
+const iconRail = {
+  mainItems: [{ id: 'inbox', label: 'Inbox', icon: Inbox, to: '/inbox' }],
+  utilityItems: [{ id: 'settings', label: 'Settings', icon: Settings, to: '/settings' }],
+};
 
 export function App() {
   return (
     <MedaShellProvider workspace={workspace} apps={apps}>
-      <AppShell>
-        <ShellHeader />
-        <AppShellBody>{/* app content */}</AppShellBody>
+      <AppShell variant="workspace" iconRail={iconRail}>
+        {/* app content */}
       </AppShell>
     </MedaShellProvider>
   );
 }
 ```
 
-Subpath imports such as `@medalsocial/meda/shell`, `/chat`, `/voice`, `/timeline`, and `/panel` keep the bundle focused.
+Subpath imports such as `@medalsocial/meda/shell`, `/shell/primitives`, `/auth`, `/auth/better-auth`, `/recipes/next`, `/theme`, `/chat`, `/voice`, `/timeline`, and `/panel` keep the bundle focused.

--- a/src/__stories__/docs/Theming.mdx
+++ b/src/__stories__/docs/Theming.mdx
@@ -39,3 +39,37 @@ Use `dark:bg-card`, `dark:text-foreground`, and related utilities without extra 
 ## Checking canonical values
 
 The [Foundations / Color](?path=/docs/foundations-color--docs) page shows the full primitive ramp and semantic mapping. Use it as the source of truth.
+
+## App token bridge
+
+Existing products can map their brand variables onto Meda's semantic tokens without copying long CSS blocks:
+
+```ts
+import { createMedaThemeCss, defineMedaTheme } from '@medalsocial/meda/theme';
+
+const autoTheme = defineMedaTheme({
+  appId: 'auto',
+  colors: {
+    primary: 'var(--hb-brand-500)',
+  },
+  fonts: {
+    body: 'var(--font-body)',
+  },
+  light: {
+    colors: {
+      background: 'var(--hb-base-50)',
+      foreground: 'var(--hb-base-950)',
+    },
+  },
+  dark: {
+    colors: {
+      background: 'var(--hb-base-900)',
+      foreground: 'var(--hb-base-50)',
+    },
+  },
+});
+
+const css = createMedaThemeCss(autoTheme);
+```
+
+Apply the generated CSS under `[data-meda-app="auto"]`, then set that attribute on the app root.


### PR DESCRIPTION
## Summary
- add a Storybook adoption guide for Next links, route-owned panels, auth controls, and theme bridge usage
- refresh install/theming/get-started docs for the current AppShell adoption APIs
- update README exports and registry install examples
- extend story authoring guidance for recipe accessibility/composition contracts

## Verification
- pnpm check:stories
- pnpm storybook:build
- pnpm typecheck
- pnpm test (via commit hook)
- pnpm lint (via commit hook, existing warnings only)