### PR TITLE
feat(shell): make WorkspaceSwitcher menu items configurable via AppShell

### DIFF
--- a/.changeset/feat-workspace-menu-items.md
+++ b/.changeset/feat-workspace-menu-items.md
@@ -1,0 +1,26 @@
+---
+"@medalsocial/meda": minor
+---
+
+`<AppShell variant="workspace">` now accepts a `workspace` config that lets consumers replace the WorkspaceSwitcher's package-default dropdown items with their own. Previously the "Manage workspaces / Settings / Profile / Sign out" entries were hardcoded inside `WorkspaceSwitcher` with no `onClick` or `href`, so they did nothing when clicked — a blocker for any real adopter.
+
+```tsx
+<AppShell
+  variant="workspace"
+  workspace={{
+    menuItems: [
+      { id: 'settings', label: 'Settings', href: '/settings/users' },
+      { id: 'profile',  label: 'Profile',  href: '/identity' },
+      { id: 'sign-out', label: 'Sign out', onClick: () => signOut(), variant: 'destructive' },
+    ],
+    menuFooter: <CustomBottomSlot />,
+  }}
+  iconRail={...}
+>
+```
+
+The new `WorkspaceMenuItem` shape supports `href`, `onClick`, optional `icon`, optional `separatorAfter`, and a `variant: 'default' | 'destructive'` tone hint. When `menuItems` is omitted the package-default items render unchanged (1.x behavior), so this is fully additive and non-breaking.
+
+The theme toggle is preserved automatically — meda still inserts it between the items and the footer so consumers don't need to reimplement theme cycling.
+
+`WorkspaceSwitcherProps.menuFooter` is the preferred name; `workspaceMenuFooter` is kept as a deprecated alias for backwards compatibility.

--- a/.changeset/icon-rail-tailwind-source.md
+++ b/.changeset/icon-rail-tailwind-source.md
@@ -1,0 +1,7 @@
+---
+"@medalsocial/meda": patch
+---
+
+Fix `<AppShell variant="workspace">` IconRail layout collapsing when consumed via Tailwind v4. Meda's exported `theme.css` now declares `@source "../**/*.js"` so utility classes used only by meda components (e.g. `h-full`, `mt-auto`, `py-3.5`, `bg-shell-rail`) are generated even when the consumer app doesn't reference them itself.
+
+Without this directive, Tailwind v4 silently dropped those classes and the IconRail rendered with content height instead of full viewport height — utility items stacked tight against the divider near the top of the rail instead of pinning to the bottom, and the first icon sat flush against the header. The directive is resolved relative to the CSS file location at build time, so it scans the package's own dist output regardless of where it's installed.

--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -32,6 +32,13 @@
 //   headroom. Note: in PR #61 these move to data-view/gantt and the timeline
 //   subpath will reclaim headroom; consider lowering then.
 //
+// theme.css raised 2 kB → 2.5 kB (PR #80):
+//   Added `@source "../**/*.js"` directive so consumer Tailwind v4 builds emit
+//   utility classes meda components rely on, plus a base `color-scheme` block
+//   bound to the resolved theme so native UA controls follow the in-app
+//   palette. Measured 2.07 kB brotli — 66 B over the previous limit. Bumped
+//   to 2.5 kB for ~20% headroom.
+//
 // Sub-entry split for shell (provider / desktop / mobile / palette) is
 // deferred to v1.x — decision pinned to real consumer adoption data, not
 // upfront speculation. See plan file Decision C history for context.
@@ -69,7 +76,7 @@ module.exports = [
   {
     name: 'theme.css',
     path: 'dist/styles/theme.css',
-    limit: '2 kB',
+    limit: '2.5 kB',
   },
   {
     // Bumped from 1 kB → 2 kB: canonical .lib.pen contract adds 6 full color

--- a/src/shell/app-shell-workspace.tsx
+++ b/src/shell/app-shell-workspace.tsx
@@ -14,6 +14,7 @@ import type {
   AppShellContextRailConfig,
   AppShellIconRailConfig,
   AppShellRightPanelConfig,
+  AppShellWorkspaceConfig,
   MobileBottomNavItem,
   PanelView,
 } from './types.js';
@@ -25,6 +26,7 @@ export interface AppShellWorkspaceProps {
   iconRail?: AppShellIconRailConfig;
   contextRail?: AppShellContextRailConfig;
   rightPanel?: AppShellRightPanelConfig;
+  workspace?: AppShellWorkspaceConfig;
   globalActions?: ReactNode;
   children: ReactNode;
 }
@@ -33,6 +35,7 @@ export function AppShellWorkspace({
   iconRail,
   contextRail,
   rightPanel,
+  workspace,
   globalActions,
   children,
 }: AppShellWorkspaceProps) {
@@ -68,7 +71,11 @@ export function AppShellWorkspace({
       {isMobile ? (
         <MobileHeader globalActions={globalActions} />
       ) : (
-        <ShellHeader globalActions={globalActions} />
+        <ShellHeader
+          globalActions={globalActions}
+          workspaceMenuItems={workspace?.menuItems}
+          workspaceMenuFooter={workspace?.menuFooter}
+        />
       )}
       <div className="relative flex flex-1 overflow-hidden">
         {!isMobile && iconRail && (

--- a/src/shell/app-shell.tsx
+++ b/src/shell/app-shell.tsx
@@ -12,6 +12,7 @@ import type {
   AppShellContextRailConfig,
   AppShellIconRailConfig,
   AppShellRightPanelConfig,
+  AppShellWorkspaceConfig,
 } from './types.js';
 
 interface AppShellBaseProps {
@@ -33,6 +34,12 @@ export type AppShellProps = AppShellBaseProps &
         iconRail?: AppShellIconRailConfig;
         contextRail?: AppShellContextRailConfig;
         rightPanel?: AppShellRightPanelConfig;
+        /**
+         * Configurable workspace dropdown — replaces the package-default
+         * "Manage workspaces / Settings / Profile / Sign out" entries when
+         * `menuItems` is provided. The theme toggle is preserved automatically.
+         */
+        workspace?: AppShellWorkspaceConfig;
         globalActions?: ReactNode;
       }
     | {
@@ -69,6 +76,7 @@ export function AppShell(props: AppShellProps) {
           iconRail={props.iconRail}
           contextRail={props.contextRail}
           rightPanel={props.rightPanel}
+          workspace={props.workspace}
           globalActions={props.globalActions}
         >
           {props.children}

--- a/src/shell/index.ts
+++ b/src/shell/index.ts
@@ -64,6 +64,7 @@ export type {
   AppShellIconRailConfig,
   AppShellRightPanelConfig,
   AppShellVariant,
+  AppShellWorkspaceConfig,
   CommandDefinition,
   ContextItem,
   ContextModule,
@@ -76,5 +77,6 @@ export type {
   ShellViewport,
   ThemeAdapter,
   WorkspaceDefinition,
+  WorkspaceMenuItem,
 } from './types.js';
 export { useShellViewport } from './use-shell-viewport.js';

--- a/src/shell/shell-header.test.tsx
+++ b/src/shell/shell-header.test.tsx
@@ -176,6 +176,93 @@ describe('WorkspaceSwitcher — workspaceMenuFooter slot renders extra items', (
 
     expect(screen.getByText('Footer Item')).toBeInTheDocument();
   });
+
+  it('menuFooter is the preferred alias and wins when both are supplied', () => {
+    renderWithProvider(
+      <WorkspaceSwitcher
+        menuFooter={<div>New Footer</div>}
+        workspaceMenuFooter={<div>Legacy Footer</div>}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /acme corp/i }));
+
+    expect(screen.getByText('New Footer')).toBeInTheDocument();
+    expect(screen.queryByText('Legacy Footer')).not.toBeInTheDocument();
+  });
+});
+
+describe('WorkspaceSwitcher — menuItems replaces hardcoded defaults', () => {
+  it('renders configured items in order, drops the default ones', () => {
+    const handleSettings = vi.fn();
+    const handleSignOut = vi.fn();
+
+    renderWithProvider(
+      <WorkspaceSwitcher
+        menuItems={[
+          { id: 'settings', label: 'Account settings', onClick: handleSettings },
+          { id: 'profile', label: 'View profile', href: '/profile', separatorAfter: true },
+          { id: 'sign-out', label: 'Log out', onClick: handleSignOut, variant: 'destructive' },
+        ]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /acme corp/i }));
+
+    // Configured items render
+    expect(screen.getByText('Account settings')).toBeInTheDocument();
+    expect(screen.getByText('View profile')).toBeInTheDocument();
+    expect(screen.getByText('Log out')).toBeInTheDocument();
+
+    // Default items DO NOT render
+    expect(screen.queryByText('Manage workspaces')).not.toBeInTheDocument();
+    expect(screen.queryByText('Settings')).not.toBeInTheDocument();
+    expect(screen.queryByText('Profile')).not.toBeInTheDocument();
+    expect(screen.queryByText('Sign out')).not.toBeInTheDocument();
+
+    // onClick wires through
+    fireEvent.click(screen.getByText('Account settings'));
+    expect(handleSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('still inserts the theme toggle between configured items and footer', () => {
+    renderWithProvider(
+      <WorkspaceSwitcher
+        menuItems={[{ id: 'a', label: 'Item A', onClick: () => {} }]}
+        menuFooter={<div>Custom footer</div>}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /acme corp/i }));
+
+    // Theme toggle text is one of three possible based on current theme; just
+    // assert that some "Switch to ... theme" item is present in the menu.
+    expect(screen.getByText(/switch to .* theme/i)).toBeInTheDocument();
+    expect(screen.getByText('Custom footer')).toBeInTheDocument();
+  });
+
+  it('renders destructive variant with the destructive class hint', () => {
+    renderWithProvider(
+      <WorkspaceSwitcher
+        menuItems={[{ id: 'danger', label: 'Delete', variant: 'destructive', onClick: () => {} }]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /acme corp/i }));
+
+    const destructiveItem = screen.getByText('Delete').closest('[data-variant]');
+    expect(destructiveItem).toHaveAttribute('data-variant', 'destructive');
+  });
+
+  it('empty menuItems array hides defaults and renders only the theme toggle', () => {
+    renderWithProvider(<WorkspaceSwitcher menuItems={[]} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /acme corp/i }));
+
+    expect(screen.queryByText('Manage workspaces')).not.toBeInTheDocument();
+    expect(screen.queryByText('Sign out')).not.toBeInTheDocument();
+    expect(screen.getByText(/switch to .* theme/i)).toBeInTheDocument();
+  });
 });
 
 describe('WorkspaceSwitcher — Escape closes the menu', () => {

--- a/src/shell/shell-header.test.tsx
+++ b/src/shell/shell-header.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
-import { Menu } from 'lucide-react';
+import { Menu, User } from 'lucide-react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppTabs, PanelToggle, ShellHeader, WorkspaceSwitcher } from './shell-header.js';
 import { MedaShellProvider } from './shell-provider.js';
@@ -223,6 +223,29 @@ describe('WorkspaceSwitcher — menuItems replaces hardcoded defaults', () => {
     // onClick wires through
     fireEvent.click(screen.getByText('Account settings'));
     expect(handleSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders href items as anchor links', () => {
+    renderWithProvider(
+      <WorkspaceSwitcher menuItems={[{ id: 'profile', label: 'View profile', href: '/profile' }]} />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /acme corp/i }));
+
+    const profileLink = screen.getByRole('menuitem', { name: 'View profile' });
+    expect(profileLink).toHaveAttribute('href', '/profile');
+  });
+
+  it('renders lucide icons without runtime errors', () => {
+    renderWithProvider(
+      <WorkspaceSwitcher
+        menuItems={[{ id: 'profile', label: 'View profile', href: '/profile', icon: User }]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /acme corp/i }));
+
+    expect(screen.getByText('View profile')).toBeInTheDocument();
   });
 
   it('still inserts the theme toggle between configured items and footer', () => {

--- a/src/shell/shell-header.tsx
+++ b/src/shell/shell-header.tsx
@@ -1,7 +1,8 @@
 'use client';
 
+import type { LucideIcon } from 'lucide-react';
 import { ChevronDown, Monitor, Moon, PanelRightClose, PanelRightOpen, Sun } from 'lucide-react';
-import { Fragment, type ReactNode } from 'react';
+import { createElement, Fragment, isValidElement, type ReactNode } from 'react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -67,28 +68,32 @@ export interface WorkspaceSwitcherProps {
 
 function renderConfiguredIcon(icon: WorkspaceMenuItem['icon']): ReactNode {
   if (icon == null) return null;
-  // LucideIcon-shape — callable React component with `size` prop.
-  if (typeof icon === 'function') {
-    const Icon = icon;
-    return <Icon size={16} aria-hidden="true" />;
+  if (isValidElement(icon)) return icon;
+  if (
+    typeof icon === 'string' ||
+    typeof icon === 'number' ||
+    typeof icon === 'boolean' ||
+    typeof icon === 'bigint'
+  ) {
+    return icon;
   }
-  // ReactNode — render as-is.
-  return icon;
+  if (typeof icon !== 'function' && typeof icon !== 'object') return icon;
+  // LucideIcon-shape — callable component or forwardRef component object.
+  return createElement(icon as LucideIcon, { size: 16, 'aria-hidden': true });
 }
 
 function renderConfiguredItem(item: WorkspaceMenuItem): ReactNode {
-  const handleSelect = () => {
-    item.onClick?.();
-    if (item.href != null && typeof window !== 'undefined') {
-      window.location.assign(item.href);
-    }
-  };
+  const handleSelect = () => item.onClick?.();
+  const renderLink =
+    item.href != null ? (
+      <a href={item.href}>
+        <span className="sr-only">Navigate</span>
+      </a>
+    ) : undefined;
 
-  // base-ui DropdownMenuItem accepts `render` for as-element; consumers using
-  // their own router (next/link, react-router) can wrap the page after
-  // shipping. For now we keep behavior simple and predictable.
   return (
     <DropdownMenuItem
+      render={renderLink}
       data-variant={item.variant ?? 'default'}
       className={item.variant === 'destructive' ? 'text-destructive' : undefined}
       onClick={handleSelect}

--- a/src/shell/shell-header.tsx
+++ b/src/shell/shell-header.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ChevronDown, Monitor, Moon, PanelRightClose, PanelRightOpen, Sun } from 'lucide-react';
-import type { ReactNode } from 'react';
+import { Fragment, type ReactNode } from 'react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -12,6 +12,7 @@ import {
 import { cn } from '../lib/utils.js';
 import { useMedaShell } from './shell-provider.js';
 import { useTheme } from './theme.js';
+import type { WorkspaceMenuItem } from './types.js';
 import { useShellViewport } from './use-shell-viewport.js';
 
 // ---------------------------------------------------------------------------
@@ -46,11 +47,66 @@ function ThemeToggleMenuItem() {
 // ---------------------------------------------------------------------------
 
 export interface WorkspaceSwitcherProps {
+  /**
+   * Configurable dropdown items. When provided, REPLACES the default
+   * "Manage workspaces / Settings / Profile / Sign out" entries. The theme
+   * toggle is still inserted automatically by meda — between the items and
+   * the footer — so consumers don't have to reimplement theme cycling.
+   *
+   * When omitted, the package-default items render (1.x behavior).
+   */
+  menuItems?: WorkspaceMenuItem[];
+  /**
+   * Extra content rendered after all items and the theme toggle. Backwards-
+   * compatible alias for the legacy `workspaceMenuFooter` prop.
+   */
+  menuFooter?: ReactNode;
+  /** @deprecated Use `menuFooter` instead. */
   workspaceMenuFooter?: ReactNode;
 }
 
-export function WorkspaceSwitcher({ workspaceMenuFooter }: WorkspaceSwitcherProps = {}) {
+function renderConfiguredIcon(icon: WorkspaceMenuItem['icon']): ReactNode {
+  if (icon == null) return null;
+  // LucideIcon-shape — callable React component with `size` prop.
+  if (typeof icon === 'function') {
+    const Icon = icon;
+    return <Icon size={16} aria-hidden="true" />;
+  }
+  // ReactNode — render as-is.
+  return icon;
+}
+
+function renderConfiguredItem(item: WorkspaceMenuItem): ReactNode {
+  const handleSelect = () => {
+    item.onClick?.();
+    if (item.href != null && typeof window !== 'undefined') {
+      window.location.assign(item.href);
+    }
+  };
+
+  // base-ui DropdownMenuItem accepts `render` for as-element; consumers using
+  // their own router (next/link, react-router) can wrap the page after
+  // shipping. For now we keep behavior simple and predictable.
+  return (
+    <DropdownMenuItem
+      data-variant={item.variant ?? 'default'}
+      className={item.variant === 'destructive' ? 'text-destructive' : undefined}
+      onClick={handleSelect}
+    >
+      {renderConfiguredIcon(item.icon)}
+      {item.label}
+    </DropdownMenuItem>
+  );
+}
+
+export function WorkspaceSwitcher({
+  menuItems,
+  menuFooter,
+  workspaceMenuFooter,
+}: WorkspaceSwitcherProps = {}) {
   const { workspace, workspaces } = useMedaShell();
+  const resolvedFooter = menuFooter ?? workspaceMenuFooter;
+  const useConfiguredItems = Array.isArray(menuItems);
 
   return (
     <DropdownMenu>
@@ -86,20 +142,32 @@ export function WorkspaceSwitcher({ workspaceMenuFooter }: WorkspaceSwitcherProp
           </>
         )}
 
-        <DropdownMenuItem>Manage workspaces</DropdownMenuItem>
-
-        <DropdownMenuSeparator />
-
-        <DropdownMenuItem>Settings</DropdownMenuItem>
-        <DropdownMenuItem>Profile</DropdownMenuItem>
+        {useConfiguredItems ? (
+          menuItems.map((item) => (
+            <Fragment key={item.id}>
+              {renderConfiguredItem(item)}
+              {item.separatorAfter && <DropdownMenuSeparator />}
+            </Fragment>
+          ))
+        ) : (
+          <>
+            <DropdownMenuItem>Manage workspaces</DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem>Settings</DropdownMenuItem>
+            <DropdownMenuItem>Profile</DropdownMenuItem>
+          </>
+        )}
 
         <DropdownMenuSeparator />
         <ThemeToggleMenuItem />
-        <DropdownMenuSeparator />
+        {!useConfiguredItems && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem>Sign out</DropdownMenuItem>
+          </>
+        )}
 
-        <DropdownMenuItem>Sign out</DropdownMenuItem>
-
-        {workspaceMenuFooter}
+        {resolvedFooter}
       </DropdownMenuContent>
     </DropdownMenu>
   );
@@ -184,9 +252,20 @@ export function PanelToggle() {
 export interface ShellHeaderProps {
   globalActions?: ReactNode;
   className?: string;
+  /**
+   * Forwarded to the internal `<WorkspaceSwitcher>`. See
+   * `WorkspaceSwitcherProps` for the full shape.
+   */
+  workspaceMenuItems?: WorkspaceMenuItem[];
+  workspaceMenuFooter?: ReactNode;
 }
 
-export function ShellHeader({ globalActions, className }: ShellHeaderProps = {}) {
+export function ShellHeader({
+  globalActions,
+  className,
+  workspaceMenuItems,
+  workspaceMenuFooter,
+}: ShellHeaderProps = {}) {
   const band = useShellViewport();
   if (band === 'mobile') return null;
 
@@ -200,7 +279,7 @@ export function ShellHeader({ globalActions, className }: ShellHeaderProps = {})
     >
       {/* Left region: WorkspaceSwitcher then AppTabs (no separator between them) */}
       <div className="flex items-center">
-        <WorkspaceSwitcher />
+        <WorkspaceSwitcher menuItems={workspaceMenuItems} menuFooter={workspaceMenuFooter} />
         <AppTabs />
       </div>
 

--- a/src/shell/shell-header.tsx
+++ b/src/shell/shell-header.tsx
@@ -84,12 +84,7 @@ function renderConfiguredIcon(icon: WorkspaceMenuItem['icon']): ReactNode {
 
 function renderConfiguredItem(item: WorkspaceMenuItem): ReactNode {
   const handleSelect = () => item.onClick?.();
-  const renderLink =
-    item.href != null ? (
-      <a href={item.href}>
-        <span className="sr-only">Navigate</span>
-      </a>
-    ) : undefined;
+  const renderLink = item.href != null ? <a href={item.href}>{item.label}</a> : undefined;
 
   return (
     <DropdownMenuItem

--- a/src/shell/types.ts
+++ b/src/shell/types.ts
@@ -121,17 +121,18 @@ export interface AppShellRightPanelConfig {
  * be provided; supplying both makes the item a button that fires `onClick`
  * AND navigates to `href` afterwards.
  */
-export interface WorkspaceMenuItem {
+interface WorkspaceMenuItemBase {
   id: string;
   label: ReactNode;
   icon?: LucideIcon | ReactNode;
-  href?: string;
-  onClick?: () => void;
   /** Insert a `<DropdownMenuSeparator />` immediately after this item. */
   separatorAfter?: boolean;
   /** Visual intent — `destructive` paints with the destructive token. */
   variant?: 'default' | 'destructive';
 }
+
+export type WorkspaceMenuItem = WorkspaceMenuItemBase &
+  ({ href: string; onClick?: () => void } | { onClick: () => void; href?: string });
 
 /**
  * Workspace dropdown configuration for `<AppShell variant="workspace">`.

--- a/src/shell/types.ts
+++ b/src/shell/types.ts
@@ -115,6 +115,41 @@ export interface AppShellRightPanelConfig {
   defaultView?: string;
 }
 
+/**
+ * A single configurable item in the WorkspaceSwitcher dropdown.
+ * Either `href` (renders as a link) or `onClick` (renders as a button) MUST
+ * be provided; supplying both makes the item a button that fires `onClick`
+ * AND navigates to `href` afterwards.
+ */
+export interface WorkspaceMenuItem {
+  id: string;
+  label: ReactNode;
+  icon?: LucideIcon | ReactNode;
+  href?: string;
+  onClick?: () => void;
+  /** Insert a `<DropdownMenuSeparator />` immediately after this item. */
+  separatorAfter?: boolean;
+  /** Visual intent — `destructive` paints with the destructive token. */
+  variant?: 'default' | 'destructive';
+}
+
+/**
+ * Workspace dropdown configuration for `<AppShell variant="workspace">`.
+ *
+ * When `menuItems` is provided, it REPLACES the package-default menu
+ * ("Manage workspaces", "Settings", "Profile", "Sign out"). The theme toggle
+ * is still inserted automatically by meda — between the items and the footer
+ * — so consumers don't have to reimplement theme cycling.
+ *
+ * When `menuItems` is omitted, the package defaults render unchanged (the
+ * existing 1.x behavior). This is fully additive and non-breaking.
+ */
+export interface AppShellWorkspaceConfig {
+  menuItems?: WorkspaceMenuItem[];
+  /** Extra slot rendered after all items and the theme toggle. */
+  menuFooter?: ReactNode;
+}
+
 export interface AppShellAuthConfig {
   title: ReactNode;
   description?: ReactNode;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -11,6 +11,17 @@
 
 @custom-variant dark (&:is(.dark *, [data-theme="dark"] *));
 
+@layer base {
+  :root {
+    color-scheme: light;
+  }
+
+  .dark,
+  [data-theme="dark"] {
+    color-scheme: dark;
+  }
+}
+
 @theme inline {
   /* Color primitives — exposed as Tailwind color scales */
 

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,5 +1,14 @@
 @import "./tokens.css";
 
+/* Tell Tailwind v4 to scan meda's compiled component output so utilities
+   like `h-full`, `mt-auto`, `py-3.5`, and `bg-shell-rail` (used by IconRail,
+   AppShellWorkspace, etc.) are generated even when the consumer app doesn't
+   reference them itself. Without this, consumers see broken layout where
+   meda components rely on classes the app doesn't otherwise use. Path is
+   resolved relative to this CSS file at build time, so it points to the
+   sibling component output regardless of where the package is installed. */
+@source "../**/*.js";
+
 @custom-variant dark (&:is(.dark *, [data-theme="dark"] *));
 
 @theme inline {

--- a/src/styles/theme.test.ts
+++ b/src/styles/theme.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+// Read theme.css via Node's runtime APIs without pulling in @types/node.
+// Declared locally so the package-level tsconfig (which doesn't include
+// node typings) still typechecks cleanly under jsdom Vitest runs.
+declare const require: (id: string) => unknown;
+declare const __dirname: string;
+
+const fs = require('node:fs') as { readFileSync(p: string, enc: string): string };
+const path = require('node:path') as { join(...parts: string[]): string };
+const themeCss = fs.readFileSync(path.join(__dirname, 'theme.css'), 'utf8');
+
+describe('theme.css', () => {
+  // Tailwind v4 only generates utility classes for class names it sees in
+  // scanned files. Consumer apps don't reference every utility used by meda
+  // components (e.g. `h-full`, `mt-auto`, `py-3.5`, `bg-shell-rail` on
+  // IconRail), so without an @source directive pointing at meda's compiled
+  // dist files, those classes silently disappear and component layouts
+  // collapse — most visibly, the IconRail's utility items fail to pin to
+  // the bottom of the viewport because `mt-auto` never gets generated.
+  //
+  // The directive is resolved relative to this CSS file at build time. Since
+  // src/styles/theme.css is copied verbatim to dist/styles/theme.css by the
+  // build script, `../**/*.js` from the dist location scans every emitted
+  // component module — exactly the surface consumers import from.
+  it('declares an @source directive that scans meda component output', () => {
+    expect(themeCss).toMatch(/@source\s+["']\.\.\/\*\*\/\*\.js["']/);
+  });
+});


### PR DESCRIPTION
## Why

`<WorkspaceSwitcher>`'s dropdown items — **Manage workspaces**, **Settings**, **Profile**, **Sign out** — are hardcoded inside the component with no `onClick`, `href`, or `render` prop. Combined with `<AppShell variant="workspace">` auto-mounting `<ShellHeader>` (which auto-mounts `<WorkspaceSwitcher>`) without forwarding props, this means the entire workspace menu does nothing when clicked. The "Switch to system theme" item is the only working one (it uses `useTheme()` internally), creating an inconsistent menu experience.

This is the **first surface every adopter clicks** when migrating to meda's workspace shell. Discovered during the `apps/auto` migration in `housebets-labs` — see [the friction notes the Auto team filed](https://github.com/arbitrium-platform/housebets-labs/blob/main/docs/superpowers/guides/2026-04-29-meda-improvements-for-auto.md) for full context plus 11 other items deferred to follow-up PRs.

## What

Adds a `workspace` config to `<AppShell variant="workspace">` that flows through `<AppShellWorkspace>` → `<ShellHeader>` → `<WorkspaceSwitcher>`. When `menuItems` is provided, it **replaces** the package-default entries entirely. The theme toggle is preserved automatically — meda still inserts it between the items and the optional footer so consumers don't have to reimplement theme cycling.

## Usage

```tsx
<AppShell
  variant="workspace"
  workspace={{
    menuItems: [
      { id: 'settings', label: 'Settings', href: '/settings' },
      { id: 'profile',  label: 'Profile',  href: '/identity', separatorAfter: true },
      { id: 'sign-out', label: 'Sign out', onClick: () => signOut(), variant: 'destructive' },
    ],
    menuFooter: <CustomFooter />,
  }}
  iconRail={...}
>
```

## API additions

| New / Modified | Surface | Description |
|---|---|---|
| `WorkspaceMenuItem` (new type, exported) | `./types` | `{ id, label, icon?, href?, onClick?, separatorAfter?, variant? }` |
| `AppShellWorkspaceConfig` (new type, exported) | `./types` | `{ menuItems?, menuFooter? }` |
| `AppShellProps['workspace']` (new prop, workspace variant) | `./app-shell` | Flows through to `WorkspaceSwitcher`. |
| `AppShellWorkspaceProps['workspace']` (new prop) | `./app-shell-workspace` | Internal pass-through. |
| `ShellHeaderProps['workspaceMenuItems']` & `['workspaceMenuFooter']` (new props) | `./shell-header` | Internal pass-through. |
| `WorkspaceSwitcherProps['menuItems']` & `['menuFooter']` (new props) | `./shell-header` | The actual rendering surface. |
| `WorkspaceSwitcherProps['workspaceMenuFooter']` | `./shell-header` | Marked `@deprecated` — alias for `menuFooter`. |

## Backwards compatibility

Fully additive — when `menuItems` is omitted the existing 1.x default items render unchanged. Existing consumers see no behavior change. The `workspaceMenuFooter` prop name is preserved as a deprecated alias of the new `menuFooter`; supplying both makes `menuFooter` win.

## Tests

5 new tests in `src/shell/shell-header.test.tsx`, covering:
- Configured items replace the defaults (and `onClick` wires through)
- Theme toggle is still inserted between custom items and footer
- `destructive` variant gets the `data-variant="destructive"` attribute
- Empty `menuItems: []` array hides defaults but keeps theme toggle
- `menuFooter` wins over the legacy `workspaceMenuFooter` when both are supplied

`pnpm test` passes 526/526 (24/24 in `shell-header.test.tsx`). `pnpm typecheck` clean. `pnpm lint` shows the same pre-existing warnings as `dev` (no new errors).

## Changeset

Added `.changeset/feat-workspace-menu-items.md` (`minor` bump).

## Follow-ups (not in this PR)

Per [the Auto team's friction notes](https://github.com/arbitrium-platform/housebets-labs/blob/main/docs/superpowers/guides/2026-04-29-meda-improvements-for-auto.md):

1. `MedaShellProvider` accepts `workspaces?: WorkspaceDefinition[]` ✅ already present on `dev` (good!)
2. `AppDefinition.icon: ReactNode | LucideIcon` (currently restricted to `LucideIcon`)
3. `AppTabs` `to` / `renderLink` for navigation (resolves the in-source `TODO(Phase 18.x)`)
4. `<AppShell variant="workspace">` `banners` slot for system-level banners (impersonation, health alerts)
5. `<AppShell variant="workspace">` `header` override for full-replacement
6. `<Skeleton />` primitive
7. Docs note on the Layer 1 → Layer N consumer override pattern
8. `IconRail.pinnedBottom` persisted via `ShellStorageAdapter`

---

## Follow-up: IconRail Tailwind v4 layout fix (`8f5a0a6`)

Same migration also surfaced a layout collapse on `<AppShell variant="workspace">` when `iconRail` is configured: utility items rendered tight against the divider near the top of the rail instead of pinning to the viewport bottom, and the first icon hugged the header's bottom edge.

**Root cause:** Tailwind v4 only generates utility classes for class names it sees in scanned files. Consumer apps (auto in this case) don't reference every class meda's components rely on — `h-full`, `mt-auto`, `py-3.5`, `bg-shell-rail` on `IconRail` are all examples — so those classes were silently dropped from the generated CSS, leaving the rail with no height, no padding, and no auto-margin pinning behaviour.

**Fix:** add `@source "../**/*.js"` to the exported `dist/styles/theme.css`. The directive is resolved relative to the CSS file location at consumer build time, so it scans meda's own dist output regardless of install location. No public API change; previously-broken layout becomes correct without consumer config.

Guard test in `src/styles/theme.test.ts` asserts the directive remains in source.
