### PR TITLE
fix(shell): export workspace types, enforce menu item contract, render href/icons correctly

### DIFF
--- a/src/shell/index.ts
+++ b/src/shell/index.ts
@@ -64,6 +64,7 @@ export type {
   AppShellIconRailConfig,
   AppShellRightPanelConfig,
   AppShellVariant,
+  AppShellWorkspaceConfig,
   CommandDefinition,
   ContextItem,
   ContextModule,
@@ -76,5 +77,6 @@ export type {
   ShellViewport,
   ThemeAdapter,
   WorkspaceDefinition,
+  WorkspaceMenuItem,
 } from './types.js';
 export { useShellViewport } from './use-shell-viewport.js';

--- a/src/shell/shell-header.test.tsx
+++ b/src/shell/shell-header.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
-import { Menu } from 'lucide-react';
+import { Menu, User } from 'lucide-react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppTabs, PanelToggle, ShellHeader, WorkspaceSwitcher } from './shell-header.js';
 import { MedaShellProvider } from './shell-provider.js';
@@ -223,6 +223,29 @@ describe('WorkspaceSwitcher — menuItems replaces hardcoded defaults', () => {
     // onClick wires through
     fireEvent.click(screen.getByText('Account settings'));
     expect(handleSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders href items as anchor links', () => {
+    renderWithProvider(
+      <WorkspaceSwitcher menuItems={[{ id: 'profile', label: 'View profile', href: '/profile' }]} />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /acme corp/i }));
+
+    const profileLink = screen.getByRole('menuitem', { name: 'View profile' });
+    expect(profileLink).toHaveAttribute('href', '/profile');
+  });
+
+  it('renders lucide icons without runtime errors', () => {
+    renderWithProvider(
+      <WorkspaceSwitcher
+        menuItems={[{ id: 'profile', label: 'View profile', href: '/profile', icon: User }]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /acme corp/i }));
+
+    expect(screen.getByText('View profile')).toBeInTheDocument();
   });
 
   it('still inserts the theme toggle between configured items and footer', () => {

--- a/src/shell/shell-header.tsx
+++ b/src/shell/shell-header.tsx
@@ -1,7 +1,8 @@
 'use client';
 
+import type { LucideIcon } from 'lucide-react';
 import { ChevronDown, Monitor, Moon, PanelRightClose, PanelRightOpen, Sun } from 'lucide-react';
-import { Fragment, type ReactNode } from 'react';
+import { createElement, Fragment, isValidElement, type ReactNode } from 'react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -67,28 +68,32 @@ export interface WorkspaceSwitcherProps {
 
 function renderConfiguredIcon(icon: WorkspaceMenuItem['icon']): ReactNode {
   if (icon == null) return null;
-  // LucideIcon-shape — callable React component with `size` prop.
-  if (typeof icon === 'function') {
-    const Icon = icon;
-    return <Icon size={16} aria-hidden="true" />;
+  if (isValidElement(icon)) return icon;
+  if (
+    typeof icon === 'string' ||
+    typeof icon === 'number' ||
+    typeof icon === 'boolean' ||
+    typeof icon === 'bigint'
+  ) {
+    return icon;
   }
-  // ReactNode — render as-is.
-  return icon;
+  if (typeof icon !== 'function' && typeof icon !== 'object') return icon;
+  // LucideIcon-shape — callable component or forwardRef component object.
+  return createElement(icon as LucideIcon, { size: 16, 'aria-hidden': true });
 }
 
 function renderConfiguredItem(item: WorkspaceMenuItem): ReactNode {
-  const handleSelect = () => {
-    item.onClick?.();
-    if (item.href != null && typeof window !== 'undefined') {
-      window.location.assign(item.href);
-    }
-  };
+  const handleSelect = () => item.onClick?.();
+  const renderLink =
+    item.href != null ? (
+      <a href={item.href}>
+        <span className="sr-only">Navigate</span>
+      </a>
+    ) : undefined;
 
-  // base-ui DropdownMenuItem accepts `render` for as-element; consumers using
-  // their own router (next/link, react-router) can wrap the page after
-  // shipping. For now we keep behavior simple and predictable.
   return (
     <DropdownMenuItem
+      render={renderLink}
       data-variant={item.variant ?? 'default'}
       className={item.variant === 'destructive' ? 'text-destructive' : undefined}
       onClick={handleSelect}

--- a/src/shell/types.ts
+++ b/src/shell/types.ts
@@ -121,17 +121,18 @@ export interface AppShellRightPanelConfig {
  * be provided; supplying both makes the item a button that fires `onClick`
  * AND navigates to `href` afterwards.
  */
-export interface WorkspaceMenuItem {
+interface WorkspaceMenuItemBase {
   id: string;
   label: ReactNode;
   icon?: LucideIcon | ReactNode;
-  href?: string;
-  onClick?: () => void;
   /** Insert a `<DropdownMenuSeparator />` immediately after this item. */
   separatorAfter?: boolean;
   /** Visual intent — `destructive` paints with the destructive token. */
   variant?: 'default' | 'destructive';
 }
+
+export type WorkspaceMenuItem = WorkspaceMenuItemBase &
+  ({ href: string; onClick?: () => void } | { onClick: () => void; href?: string });
 
 /**
  * Workspace dropdown configuration for `<AppShell variant="workspace">`.


### PR DESCRIPTION
### Motivation
- Address PR review feedback that the new `WorkspaceMenuItem`/`AppShellWorkspaceConfig` API was not fully usable and had runtime/typing issues. 
- Prevent consumers from configuring inert menu entries and fix incorrect rendering of `href` and icon values in the `WorkspaceSwitcher`.

### Description
- Exported `WorkspaceMenuItem` and `AppShellWorkspaceConfig` from the shell barrel so the new types are available from the package entrypoint (`src/shell/index.ts`).
- Tightened the `WorkspaceMenuItem` type into a union that requires at least one action (`href` or `onClick`) so items cannot be inert (`src/shell/types.ts`).
- Updated `WorkspaceSwitcher` rendering to use a real anchor for `href` items, preserve `onClick` callbacks, and render Lucide icons (including `forwardRef` objects) safely via `createElement` and `isValidElement` checks (`src/shell/shell-header.tsx`).
- Added regression tests covering configured menu replacement, `href` items rendering as links, and Lucide icon rendering (`src/shell/shell-header.test.tsx`).

### Testing
- Ran `pnpm typecheck` and the TypeScript check completed successfully.
- Ran the targeted unit tests with `pnpm test src/shell/shell-header.test.tsx` and all tests passed (`26/26` in that file).
- Attempted to run the full test/pre-commit suite, but Playwright browser downloads are blocked in this environment (HTTP 403 from `cdn.playwright.dev`), which prevented the full suite from completing; targeted typecheck and unit tests were used to validate the changes instead.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f25c5c8a408321b614c9123128157f)