### PR TITLE
Fix WorkspaceSwitcher menu link labels and improve theme defaults

### DIFF
--- a/src/shell/shell-header.tsx
+++ b/src/shell/shell-header.tsx
@@ -84,12 +84,7 @@ function renderConfiguredIcon(icon: WorkspaceMenuItem['icon']): ReactNode {
 
 function renderConfiguredItem(item: WorkspaceMenuItem): ReactNode {
   const handleSelect = () => item.onClick?.();
-  const renderLink =
-    item.href != null ? (
-      <a href={item.href}>
-        <span className="sr-only">Navigate</span>
-      </a>
-    ) : undefined;
+  const renderLink = item.href != null ? <a href={item.href}>{item.label}</a> : undefined;
 
   return (
     <DropdownMenuItem

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -13,7 +13,12 @@
 
 @layer base {
   :root {
-    color-scheme: light dark;
+    color-scheme: light;
+  }
+
+  .dark,
+  [data-theme="dark"] {
+    color-scheme: dark;
   }
 }
 

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -11,6 +11,12 @@
 
 @custom-variant dark (&:is(.dark *, [data-theme="dark"] *));
 
+@layer base {
+  :root {
+    color-scheme: light dark;
+  }
+}
+
 @theme inline {
   /* Color primitives — exposed as Tailwind color scales */
 


### PR DESCRIPTION
### Motivation
- Ensure custom `menuItems` render accessible/menuitem text correctly so configured link items show their label rather than an sr-only placeholder.
- Make the theme stylesheet more robust for dual light/dark rendering by providing a base `color-scheme` hint to user agents.

### Description
- Changed `WorkspaceSwitcher` link rendering so href entries render the configured label inside the anchor (`<a href={item.href}>{item.label}</a>`) instead of an internal sr-only placeholder (file: `src/shell/shell-header.tsx`).
- Added a base `color-scheme: light dark` declaration inside a `@layer base` block in `src/styles/theme.css` to align native control rendering with the package themes.
- Ran `biome format` to update formatting for the modified files.

### Testing
- Ran the focused unit test with `pnpm -s vitest src/shell/shell-header.test.tsx --project unit` and it passed (`26 passed`).
- Ran the full test suite with `pnpm -s test` which showed application tests passing but the run exited with an environment Playwright/browser error (`browserType.launch` missing chromium headless shell), so the failure is due to the test environment lacking Playwright browser binaries rather than code regressions.
- Attempted to remediate with `pnpm exec playwright install chromium`, but the download was blocked by the environment proxy (`403 Domain forbidden`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f25f8fdce88321b1091e4ec8899193)