### PR TITLE
Release: dev → prod (workspace menu config, IconRail fix, theme polish)

### DIFF
--- a/.changeset/feat-workspace-menu-items.md
+++ b/.changeset/feat-workspace-menu-items.md
@@ -1,0 +1,26 @@
+---
+"@medalsocial/meda": minor
+---
+
+`<AppShell variant="workspace">` now accepts a `workspace` config that lets consumers replace the WorkspaceSwitcher's package-default dropdown items with their own. Previously the "Manage workspaces / Settings / Profile / Sign out" entries were hardcoded inside `WorkspaceSwitcher` with no `onClick` or `href`, so they did nothing when clicked — a blocker for any real adopter.
+
+```tsx
+<AppShell
+  variant="workspace"
+  workspace={{
+    menuItems: [
+      { id: 'settings', label: 'Settings', href: '/settings/users' },
+      { id: 'profile',  label: 'Profile',  href: '/identity' },
+      { id: 'sign-out', label: 'Sign out', onClick: () => signOut(), variant: 'destructive' },
+    ],
+    menuFooter: <CustomBottomSlot />,
+  }}
+  iconRail={...}
+>
+```
+
+The new `WorkspaceMenuItem` shape supports `href`, `onClick`, optional `icon`, optional `separatorAfter`, and a `variant: 'default' | 'destructive'` tone hint. When `menuItems` is omitted the package-default items render unchanged (1.x behavior), so this is fully additive and non-breaking.
+
+The theme toggle is preserved automatically — meda still inserts it between the items and the footer so consumers don't need to reimplement theme cycling.
+
+`WorkspaceSwitcherProps.menuFooter` is the preferred name; `workspaceMenuFooter` is kept as a deprecated alias for backwards compatibility.

--- a/.changeset/fix-workspace-menu-icon-render.md
+++ b/.changeset/fix-workspace-menu-icon-render.md
@@ -1,0 +1,17 @@
+---
+'@medalsocial/meda': patch
+---
+
+fix(shell): preserve icon on `href` workspace menu items and avoid icon-render crash
+
+- `WorkspaceMenuItem` entries with `href` now render their icon. The previous
+  implementation passed `<a href={item.href}>{item.label}</a>` to Base UI's
+  `render` prop, and the cloned anchor's own children overrode the
+  `DropdownMenuItem` children, silently dropping the icon. The anchor is now
+  childless so Base UI merges the menuitem's icon + label children into it.
+- `renderConfiguredIcon` no longer crashes when `icon` is a non-element
+  `ReactNode` object (e.g. an array of nodes). Previously any non-primitive,
+  non-element value fell through to `createElement`, producing
+  "Element type is invalid". The function now only invokes `createElement` for
+  callable components and `forwardRef`/`memo`-shaped objects, and renders any
+  other `ReactNode` as-is.

--- a/.changeset/icon-rail-tailwind-source.md
+++ b/.changeset/icon-rail-tailwind-source.md
@@ -1,0 +1,7 @@
+---
+"@medalsocial/meda": patch
+---
+
+Fix `<AppShell variant="workspace">` IconRail layout collapsing when consumed via Tailwind v4. Meda's exported `theme.css` now declares `@source "../**/*.js"` so utility classes used only by meda components (e.g. `h-full`, `mt-auto`, `py-3.5`, `bg-shell-rail`) are generated even when the consumer app doesn't reference them itself.
+
+Without this directive, Tailwind v4 silently dropped those classes and the IconRail rendered with content height instead of full viewport height — utility items stacked tight against the divider near the top of the rail instead of pinning to the bottom, and the first icon sat flush against the header. The directive is resolved relative to the CSS file location at build time, so it scans the package's own dist output regardless of where it's installed.

--- a/.changeset/meda-auth-adoption-controls.md
+++ b/.changeset/meda-auth-adoption-controls.md
@@ -1,5 +1,0 @@
----
-'@medalsocial/meda': minor
----
-
-Adds auth adoption controls, `AppShell` auth branding shorthand, and an optional better-auth adapter subpath.

--- a/.changeset/meda-package-recipes.md
+++ b/.changeset/meda-package-recipes.md
@@ -1,5 +1,0 @@
----
-"@medalsocial/meda": minor
----
-
-Add shell primitive and Next recipe package subpaths, plus registry metadata for copyable AppShell adoption recipes.

--- a/.changeset/meda-render-prop-boundaries.md
+++ b/.changeset/meda-render-prop-boundaries.md
@@ -1,5 +1,0 @@
----
-"@medalsocial/meda": minor
----
-
-Add render-boundary adapter props for auth provider buttons, shell rail links, and right panel tabs so consumers can integrate routers, analytics, and wrapper components while preserving Meda ARIA, state, and event props.

--- a/.changeset/meda-theme-bridge-contracts.md
+++ b/.changeset/meda-theme-bridge-contracts.md
@@ -1,5 +1,0 @@
----
-"@medalsocial/meda": minor
----
-
-Add a public theme bridge helper for app-scoped Meda token CSS and strengthen Next recipe accessibility/composition contracts.

--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -32,6 +32,13 @@
 //   headroom. Note: in PR #61 these move to data-view/gantt and the timeline
 //   subpath will reclaim headroom; consider lowering then.
 //
+// theme.css raised 2 kB → 2.5 kB (PR #80):
+//   Added `@source "../**/*.js"` directive so consumer Tailwind v4 builds emit
+//   utility classes meda components rely on, plus a base `color-scheme` block
+//   bound to the resolved theme so native UA controls follow the in-app
+//   palette. Measured 2.07 kB brotli — 66 B over the previous limit. Bumped
+//   to 2.5 kB for ~20% headroom.
+//
 // Sub-entry split for shell (provider / desktop / mobile / palette) is
 // deferred to v1.x — decision pinned to real consumer adoption data, not
 // upfront speculation. See plan file Decision C history for context.
@@ -69,7 +76,7 @@ module.exports = [
   {
     name: 'theme.css',
     path: 'dist/styles/theme.css',
-    limit: '2 kB',
+    limit: '2.5 kB',
   },
   {
     // Bumped from 1 kB → 2 kB: canonical .lib.pen contract adds 6 full color

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @medalsocial/meda
 
+## 1.4.0
+
+### Minor Changes
+
+- [#73](https://github.com/Medal-Social/meda/pull/73) [`79fb98a`](https://github.com/Medal-Social/meda/commit/79fb98a31c9a29c68da70604169d1e0a8202811c) Thanks [@alioftech](https://github.com/alioftech)! - Adds auth adoption controls, `AppShell` auth branding shorthand, and an optional better-auth adapter subpath.
+
+- [#75](https://github.com/Medal-Social/meda/pull/75) [`439e475`](https://github.com/Medal-Social/meda/commit/439e475e7e1c0c8f2e93fe38456d47d469f43711) Thanks [@alioftech](https://github.com/alioftech)! - Add shell primitive and Next recipe package subpaths, plus registry metadata for copyable AppShell adoption recipes.
+
+- [#74](https://github.com/Medal-Social/meda/pull/74) [`3bb777c`](https://github.com/Medal-Social/meda/commit/3bb777c23ef050a542e4786b2b0da2fcc996d071) Thanks [@alioftech](https://github.com/alioftech)! - Add render-boundary adapter props for auth provider buttons, shell rail links, and right panel tabs so consumers can integrate routers, analytics, and wrapper components while preserving Meda ARIA, state, and event props.
+
+- [#76](https://github.com/Medal-Social/meda/pull/76) [`970a8e6`](https://github.com/Medal-Social/meda/commit/970a8e6d8f8e60c68b199666c67c56f66f6a8dfd) Thanks [@alioftech](https://github.com/alioftech)! - Add a public theme bridge helper for app-scoped Meda token CSS and strengthen Next recipe accessibility/composition contracts.
+
 ## 1.3.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@medalsocial/meda",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Shared Meda UI shell and runtime package.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/shell/app-shell-workspace.tsx
+++ b/src/shell/app-shell-workspace.tsx
@@ -14,6 +14,7 @@ import type {
   AppShellContextRailConfig,
   AppShellIconRailConfig,
   AppShellRightPanelConfig,
+  AppShellWorkspaceConfig,
   MobileBottomNavItem,
   PanelView,
 } from './types.js';
@@ -25,6 +26,7 @@ export interface AppShellWorkspaceProps {
   iconRail?: AppShellIconRailConfig;
   contextRail?: AppShellContextRailConfig;
   rightPanel?: AppShellRightPanelConfig;
+  workspace?: AppShellWorkspaceConfig;
   globalActions?: ReactNode;
   children: ReactNode;
 }
@@ -33,6 +35,7 @@ export function AppShellWorkspace({
   iconRail,
   contextRail,
   rightPanel,
+  workspace,
   globalActions,
   children,
 }: AppShellWorkspaceProps) {
@@ -68,7 +71,11 @@ export function AppShellWorkspace({
       {isMobile ? (
         <MobileHeader globalActions={globalActions} />
       ) : (
-        <ShellHeader globalActions={globalActions} />
+        <ShellHeader
+          globalActions={globalActions}
+          workspaceMenuItems={workspace?.menuItems}
+          workspaceMenuFooter={workspace?.menuFooter}
+        />
       )}
       <div className="relative flex flex-1 overflow-hidden">
         {!isMobile && iconRail && (

--- a/src/shell/app-shell.tsx
+++ b/src/shell/app-shell.tsx
@@ -12,6 +12,7 @@ import type {
   AppShellContextRailConfig,
   AppShellIconRailConfig,
   AppShellRightPanelConfig,
+  AppShellWorkspaceConfig,
 } from './types.js';
 
 interface AppShellBaseProps {
@@ -33,6 +34,12 @@ export type AppShellProps = AppShellBaseProps &
         iconRail?: AppShellIconRailConfig;
         contextRail?: AppShellContextRailConfig;
         rightPanel?: AppShellRightPanelConfig;
+        /**
+         * Configurable workspace dropdown — replaces the package-default
+         * "Manage workspaces / Settings / Profile / Sign out" entries when
+         * `menuItems` is provided. The theme toggle is preserved automatically.
+         */
+        workspace?: AppShellWorkspaceConfig;
         globalActions?: ReactNode;
       }
     | {
@@ -69,6 +76,7 @@ export function AppShell(props: AppShellProps) {
           iconRail={props.iconRail}
           contextRail={props.contextRail}
           rightPanel={props.rightPanel}
+          workspace={props.workspace}
           globalActions={props.globalActions}
         >
           {props.children}

--- a/src/shell/index.ts
+++ b/src/shell/index.ts
@@ -64,6 +64,7 @@ export type {
   AppShellIconRailConfig,
   AppShellRightPanelConfig,
   AppShellVariant,
+  AppShellWorkspaceConfig,
   CommandDefinition,
   ContextItem,
   ContextModule,
@@ -76,5 +77,6 @@ export type {
   ShellViewport,
   ThemeAdapter,
   WorkspaceDefinition,
+  WorkspaceMenuItem,
 } from './types.js';
 export { useShellViewport } from './use-shell-viewport.js';

--- a/src/shell/shell-header.test.tsx
+++ b/src/shell/shell-header.test.tsx
@@ -176,6 +176,93 @@ describe('WorkspaceSwitcher — workspaceMenuFooter slot renders extra items', (
 
     expect(screen.getByText('Footer Item')).toBeInTheDocument();
   });
+
+  it('menuFooter is the preferred alias and wins when both are supplied', () => {
+    renderWithProvider(
+      <WorkspaceSwitcher
+        menuFooter={<div>New Footer</div>}
+        workspaceMenuFooter={<div>Legacy Footer</div>}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /acme corp/i }));
+
+    expect(screen.getByText('New Footer')).toBeInTheDocument();
+    expect(screen.queryByText('Legacy Footer')).not.toBeInTheDocument();
+  });
+});
+
+describe('WorkspaceSwitcher — menuItems replaces hardcoded defaults', () => {
+  it('renders configured items in order, drops the default ones', () => {
+    const handleSettings = vi.fn();
+    const handleSignOut = vi.fn();
+
+    renderWithProvider(
+      <WorkspaceSwitcher
+        menuItems={[
+          { id: 'settings', label: 'Account settings', onClick: handleSettings },
+          { id: 'profile', label: 'View profile', href: '/profile', separatorAfter: true },
+          { id: 'sign-out', label: 'Log out', onClick: handleSignOut, variant: 'destructive' },
+        ]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /acme corp/i }));
+
+    // Configured items render
+    expect(screen.getByText('Account settings')).toBeInTheDocument();
+    expect(screen.getByText('View profile')).toBeInTheDocument();
+    expect(screen.getByText('Log out')).toBeInTheDocument();
+
+    // Default items DO NOT render
+    expect(screen.queryByText('Manage workspaces')).not.toBeInTheDocument();
+    expect(screen.queryByText('Settings')).not.toBeInTheDocument();
+    expect(screen.queryByText('Profile')).not.toBeInTheDocument();
+    expect(screen.queryByText('Sign out')).not.toBeInTheDocument();
+
+    // onClick wires through
+    fireEvent.click(screen.getByText('Account settings'));
+    expect(handleSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('still inserts the theme toggle between configured items and footer', () => {
+    renderWithProvider(
+      <WorkspaceSwitcher
+        menuItems={[{ id: 'a', label: 'Item A', onClick: () => {} }]}
+        menuFooter={<div>Custom footer</div>}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /acme corp/i }));
+
+    // Theme toggle text is one of three possible based on current theme; just
+    // assert that some "Switch to ... theme" item is present in the menu.
+    expect(screen.getByText(/switch to .* theme/i)).toBeInTheDocument();
+    expect(screen.getByText('Custom footer')).toBeInTheDocument();
+  });
+
+  it('renders destructive variant with the destructive class hint', () => {
+    renderWithProvider(
+      <WorkspaceSwitcher
+        menuItems={[{ id: 'danger', label: 'Delete', variant: 'destructive', onClick: () => {} }]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /acme corp/i }));
+
+    const destructiveItem = screen.getByText('Delete').closest('[data-variant]');
+    expect(destructiveItem).toHaveAttribute('data-variant', 'destructive');
+  });
+
+  it('empty menuItems array hides defaults and renders only the theme toggle', () => {
+    renderWithProvider(<WorkspaceSwitcher menuItems={[]} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /acme corp/i }));
+
+    expect(screen.queryByText('Manage workspaces')).not.toBeInTheDocument();
+    expect(screen.queryByText('Sign out')).not.toBeInTheDocument();
+    expect(screen.getByText(/switch to .* theme/i)).toBeInTheDocument();
+  });
 });
 
 describe('WorkspaceSwitcher — Escape closes the menu', () => {

--- a/src/shell/shell-header.test.tsx
+++ b/src/shell/shell-header.test.tsx
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom/vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { Menu, User } from 'lucide-react';
+import { memo } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppTabs, PanelToggle, ShellHeader, WorkspaceSwitcher } from './shell-header.js';
 import { MedaShellProvider } from './shell-provider.js';
@@ -261,6 +262,20 @@ describe('WorkspaceSwitcher — menuItems replaces hardcoded defaults', () => {
     expect(link.tagName).toBe('A');
     expect(link).toHaveAttribute('href', '/profile');
     expect(link.querySelector('svg')).not.toBeNull();
+  });
+
+  it('renders memoized icon components without falling through', () => {
+    const MemoIcon = memo(User);
+    renderWithProvider(
+      <WorkspaceSwitcher
+        menuItems={[{ id: 'profile', label: 'View profile', onClick: () => {}, icon: MemoIcon }]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /acme corp/i }));
+
+    const item = screen.getByRole('menuitem', { name: /view profile/i });
+    expect(item.querySelector('svg')).not.toBeNull();
   });
 
   it('renders array-shaped icon ReactNodes as-is without crashing', () => {

--- a/src/shell/shell-header.test.tsx
+++ b/src/shell/shell-header.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
-import { Menu } from 'lucide-react';
+import { Menu, User } from 'lucide-react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppTabs, PanelToggle, ShellHeader, WorkspaceSwitcher } from './shell-header.js';
 import { MedaShellProvider } from './shell-provider.js';
@@ -223,6 +223,29 @@ describe('WorkspaceSwitcher — menuItems replaces hardcoded defaults', () => {
     // onClick wires through
     fireEvent.click(screen.getByText('Account settings'));
     expect(handleSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders href items as anchor links', () => {
+    renderWithProvider(
+      <WorkspaceSwitcher menuItems={[{ id: 'profile', label: 'View profile', href: '/profile' }]} />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /acme corp/i }));
+
+    const profileLink = screen.getByRole('menuitem', { name: 'View profile' });
+    expect(profileLink).toHaveAttribute('href', '/profile');
+  });
+
+  it('renders lucide icons without runtime errors', () => {
+    renderWithProvider(
+      <WorkspaceSwitcher
+        menuItems={[{ id: 'profile', label: 'View profile', href: '/profile', icon: User }]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /acme corp/i }));
+
+    expect(screen.getByText('View profile')).toBeInTheDocument();
   });
 
   it('still inserts the theme toggle between configured items and footer', () => {

--- a/src/shell/shell-header.test.tsx
+++ b/src/shell/shell-header.test.tsx
@@ -248,6 +248,48 @@ describe('WorkspaceSwitcher — menuItems replaces hardcoded defaults', () => {
     expect(screen.getByText('View profile')).toBeInTheDocument();
   });
 
+  it('preserves icon when item is rendered as an anchor link', () => {
+    renderWithProvider(
+      <WorkspaceSwitcher
+        menuItems={[{ id: 'profile', label: 'View profile', href: '/profile', icon: User }]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /acme corp/i }));
+
+    const link = screen.getByRole('menuitem', { name: 'View profile' });
+    expect(link.tagName).toBe('A');
+    expect(link).toHaveAttribute('href', '/profile');
+    expect(link.querySelector('svg')).not.toBeNull();
+  });
+
+  it('renders array-shaped icon ReactNodes as-is without crashing', () => {
+    renderWithProvider(
+      <WorkspaceSwitcher
+        menuItems={[
+          {
+            id: 'compound',
+            label: 'Compound',
+            onClick: () => {},
+            icon: [
+              <span key="a" data-testid="icon-a">
+                a
+              </span>,
+              <span key="b" data-testid="icon-b">
+                b
+              </span>,
+            ],
+          },
+        ]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /acme corp/i }));
+
+    expect(screen.getByTestId('icon-a')).toBeInTheDocument();
+    expect(screen.getByTestId('icon-b')).toBeInTheDocument();
+  });
+
   it('still inserts the theme toggle between configured items and footer', () => {
     renderWithProvider(
       <WorkspaceSwitcher

--- a/src/shell/shell-header.tsx
+++ b/src/shell/shell-header.tsx
@@ -1,7 +1,8 @@
 'use client';
 
+import type { LucideIcon } from 'lucide-react';
 import { ChevronDown, Monitor, Moon, PanelRightClose, PanelRightOpen, Sun } from 'lucide-react';
-import { Fragment, type ReactNode } from 'react';
+import { createElement, Fragment, isValidElement, type ReactNode } from 'react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -67,28 +68,32 @@ export interface WorkspaceSwitcherProps {
 
 function renderConfiguredIcon(icon: WorkspaceMenuItem['icon']): ReactNode {
   if (icon == null) return null;
-  // LucideIcon-shape — callable React component with `size` prop.
-  if (typeof icon === 'function') {
-    const Icon = icon;
-    return <Icon size={16} aria-hidden="true" />;
+  if (isValidElement(icon)) return icon;
+  if (
+    typeof icon === 'string' ||
+    typeof icon === 'number' ||
+    typeof icon === 'boolean' ||
+    typeof icon === 'bigint'
+  ) {
+    return icon;
   }
-  // ReactNode — render as-is.
-  return icon;
+  if (typeof icon !== 'function' && typeof icon !== 'object') return icon;
+  // LucideIcon-shape — callable component or forwardRef component object.
+  return createElement(icon as LucideIcon, { size: 16, 'aria-hidden': true });
 }
 
 function renderConfiguredItem(item: WorkspaceMenuItem): ReactNode {
-  const handleSelect = () => {
-    item.onClick?.();
-    if (item.href != null && typeof window !== 'undefined') {
-      window.location.assign(item.href);
-    }
-  };
+  const handleSelect = () => item.onClick?.();
+  const renderLink =
+    item.href != null ? (
+      <a href={item.href}>
+        <span className="sr-only">Navigate</span>
+      </a>
+    ) : undefined;
 
-  // base-ui DropdownMenuItem accepts `render` for as-element; consumers using
-  // their own router (next/link, react-router) can wrap the page after
-  // shipping. For now we keep behavior simple and predictable.
   return (
     <DropdownMenuItem
+      render={renderLink}
       data-variant={item.variant ?? 'default'}
       className={item.variant === 'destructive' ? 'text-destructive' : undefined}
       onClick={handleSelect}

--- a/src/shell/shell-header.tsx
+++ b/src/shell/shell-header.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ChevronDown, Monitor, Moon, PanelRightClose, PanelRightOpen, Sun } from 'lucide-react';
-import type { ReactNode } from 'react';
+import { Fragment, type ReactNode } from 'react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -12,6 +12,7 @@ import {
 import { cn } from '../lib/utils.js';
 import { useMedaShell } from './shell-provider.js';
 import { useTheme } from './theme.js';
+import type { WorkspaceMenuItem } from './types.js';
 import { useShellViewport } from './use-shell-viewport.js';
 
 // ---------------------------------------------------------------------------
@@ -46,11 +47,66 @@ function ThemeToggleMenuItem() {
 // ---------------------------------------------------------------------------
 
 export interface WorkspaceSwitcherProps {
+  /**
+   * Configurable dropdown items. When provided, REPLACES the default
+   * "Manage workspaces / Settings / Profile / Sign out" entries. The theme
+   * toggle is still inserted automatically by meda — between the items and
+   * the footer — so consumers don't have to reimplement theme cycling.
+   *
+   * When omitted, the package-default items render (1.x behavior).
+   */
+  menuItems?: WorkspaceMenuItem[];
+  /**
+   * Extra content rendered after all items and the theme toggle. Backwards-
+   * compatible alias for the legacy `workspaceMenuFooter` prop.
+   */
+  menuFooter?: ReactNode;
+  /** @deprecated Use `menuFooter` instead. */
   workspaceMenuFooter?: ReactNode;
 }
 
-export function WorkspaceSwitcher({ workspaceMenuFooter }: WorkspaceSwitcherProps = {}) {
+function renderConfiguredIcon(icon: WorkspaceMenuItem['icon']): ReactNode {
+  if (icon == null) return null;
+  // LucideIcon-shape — callable React component with `size` prop.
+  if (typeof icon === 'function') {
+    const Icon = icon;
+    return <Icon size={16} aria-hidden="true" />;
+  }
+  // ReactNode — render as-is.
+  return icon;
+}
+
+function renderConfiguredItem(item: WorkspaceMenuItem): ReactNode {
+  const handleSelect = () => {
+    item.onClick?.();
+    if (item.href != null && typeof window !== 'undefined') {
+      window.location.assign(item.href);
+    }
+  };
+
+  // base-ui DropdownMenuItem accepts `render` for as-element; consumers using
+  // their own router (next/link, react-router) can wrap the page after
+  // shipping. For now we keep behavior simple and predictable.
+  return (
+    <DropdownMenuItem
+      data-variant={item.variant ?? 'default'}
+      className={item.variant === 'destructive' ? 'text-destructive' : undefined}
+      onClick={handleSelect}
+    >
+      {renderConfiguredIcon(item.icon)}
+      {item.label}
+    </DropdownMenuItem>
+  );
+}
+
+export function WorkspaceSwitcher({
+  menuItems,
+  menuFooter,
+  workspaceMenuFooter,
+}: WorkspaceSwitcherProps = {}) {
   const { workspace, workspaces } = useMedaShell();
+  const resolvedFooter = menuFooter ?? workspaceMenuFooter;
+  const useConfiguredItems = Array.isArray(menuItems);
 
   return (
     <DropdownMenu>
@@ -86,20 +142,32 @@ export function WorkspaceSwitcher({ workspaceMenuFooter }: WorkspaceSwitcherProp
           </>
         )}
 
-        <DropdownMenuItem>Manage workspaces</DropdownMenuItem>
-
-        <DropdownMenuSeparator />
-
-        <DropdownMenuItem>Settings</DropdownMenuItem>
-        <DropdownMenuItem>Profile</DropdownMenuItem>
+        {useConfiguredItems ? (
+          menuItems.map((item) => (
+            <Fragment key={item.id}>
+              {renderConfiguredItem(item)}
+              {item.separatorAfter && <DropdownMenuSeparator />}
+            </Fragment>
+          ))
+        ) : (
+          <>
+            <DropdownMenuItem>Manage workspaces</DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem>Settings</DropdownMenuItem>
+            <DropdownMenuItem>Profile</DropdownMenuItem>
+          </>
+        )}
 
         <DropdownMenuSeparator />
         <ThemeToggleMenuItem />
-        <DropdownMenuSeparator />
+        {!useConfiguredItems && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem>Sign out</DropdownMenuItem>
+          </>
+        )}
 
-        <DropdownMenuItem>Sign out</DropdownMenuItem>
-
-        {workspaceMenuFooter}
+        {resolvedFooter}
       </DropdownMenuContent>
     </DropdownMenu>
   );
@@ -184,9 +252,20 @@ export function PanelToggle() {
 export interface ShellHeaderProps {
   globalActions?: ReactNode;
   className?: string;
+  /**
+   * Forwarded to the internal `<WorkspaceSwitcher>`. See
+   * `WorkspaceSwitcherProps` for the full shape.
+   */
+  workspaceMenuItems?: WorkspaceMenuItem[];
+  workspaceMenuFooter?: ReactNode;
 }
 
-export function ShellHeader({ globalActions, className }: ShellHeaderProps = {}) {
+export function ShellHeader({
+  globalActions,
+  className,
+  workspaceMenuItems,
+  workspaceMenuFooter,
+}: ShellHeaderProps = {}) {
   const band = useShellViewport();
   if (band === 'mobile') return null;
 
@@ -200,7 +279,7 @@ export function ShellHeader({ globalActions, className }: ShellHeaderProps = {})
     >
       {/* Left region: WorkspaceSwitcher then AppTabs (no separator between them) */}
       <div className="flex items-center">
-        <WorkspaceSwitcher />
+        <WorkspaceSwitcher menuItems={workspaceMenuItems} menuFooter={workspaceMenuFooter} />
         <AppTabs />
       </div>
 

--- a/src/shell/shell-header.tsx
+++ b/src/shell/shell-header.tsx
@@ -73,12 +73,12 @@ function renderConfiguredIcon(icon: WorkspaceMenuItem['icon']): ReactNode {
     return createElement(icon as LucideIcon, { size: 16, 'aria-hidden': true });
   }
   // forwardRef/memo components are objects carrying a `$$typeof` symbol —
-  // treat them like Lucide components. Any other object (arrays, fragments
-  // produced by jsx-runtime, plain ReactNode objects) is rendered as-is so
-  // it doesn't crash createElement with "Element type is invalid".
+  // treat them like Lucide components. Plain ReactNode objects (arrays,
+  // iterables, promises) have no `$$typeof` and are rendered as-is so they
+  // don't crash createElement with "Element type is invalid".
   if (typeof icon === 'object' && icon !== null) {
-    const candidate = icon as unknown as { $$typeof?: symbol; render?: unknown };
-    if (candidate.$$typeof != null && typeof candidate.render === 'function') {
+    const candidate = icon as unknown as { $$typeof?: symbol };
+    if (candidate.$$typeof != null) {
       return createElement(icon as unknown as LucideIcon, {
         size: 16,
         'aria-hidden': true,

--- a/src/shell/shell-header.tsx
+++ b/src/shell/shell-header.tsx
@@ -69,22 +69,31 @@ export interface WorkspaceSwitcherProps {
 function renderConfiguredIcon(icon: WorkspaceMenuItem['icon']): ReactNode {
   if (icon == null) return null;
   if (isValidElement(icon)) return icon;
-  if (
-    typeof icon === 'string' ||
-    typeof icon === 'number' ||
-    typeof icon === 'boolean' ||
-    typeof icon === 'bigint'
-  ) {
-    return icon;
+  if (typeof icon === 'function') {
+    return createElement(icon as LucideIcon, { size: 16, 'aria-hidden': true });
   }
-  if (typeof icon !== 'function' && typeof icon !== 'object') return icon;
-  // LucideIcon-shape — callable component or forwardRef component object.
-  return createElement(icon as LucideIcon, { size: 16, 'aria-hidden': true });
+  // forwardRef/memo components are objects carrying a `$$typeof` symbol —
+  // treat them like Lucide components. Any other object (arrays, fragments
+  // produced by jsx-runtime, plain ReactNode objects) is rendered as-is so
+  // it doesn't crash createElement with "Element type is invalid".
+  if (
+    typeof icon === 'object' &&
+    icon !== null &&
+    '$$typeof' in (icon as Record<string, unknown>) &&
+    typeof (icon as { render?: unknown }).render === 'function'
+  ) {
+    return createElement(icon as LucideIcon, { size: 16, 'aria-hidden': true });
+  }
+  return icon;
 }
 
 function renderConfiguredItem(item: WorkspaceMenuItem): ReactNode {
   const handleSelect = () => item.onClick?.();
-  const renderLink = item.href != null ? <a href={item.href}>{item.label}</a> : undefined;
+  // Childless anchor — Base UI merges the DropdownMenuItem's children into the
+  // cloned render element. Passing children here would override the icon +
+  // label children below and configured icons would silently disappear.
+  // biome-ignore lint/a11y/useAnchorContent: children are injected at render time by Base UI's `render` prop
+  const renderLink = item.href != null ? <a href={item.href} /> : undefined;
 
   return (
     <DropdownMenuItem

--- a/src/shell/shell-header.tsx
+++ b/src/shell/shell-header.tsx
@@ -76,13 +76,14 @@ function renderConfiguredIcon(icon: WorkspaceMenuItem['icon']): ReactNode {
   // treat them like Lucide components. Any other object (arrays, fragments
   // produced by jsx-runtime, plain ReactNode objects) is rendered as-is so
   // it doesn't crash createElement with "Element type is invalid".
-  if (
-    typeof icon === 'object' &&
-    icon !== null &&
-    '$$typeof' in (icon as Record<string, unknown>) &&
-    typeof (icon as { render?: unknown }).render === 'function'
-  ) {
-    return createElement(icon as LucideIcon, { size: 16, 'aria-hidden': true });
+  if (typeof icon === 'object' && icon !== null) {
+    const candidate = icon as unknown as { $$typeof?: symbol; render?: unknown };
+    if (candidate.$$typeof != null && typeof candidate.render === 'function') {
+      return createElement(icon as unknown as LucideIcon, {
+        size: 16,
+        'aria-hidden': true,
+      });
+    }
   }
   return icon;
 }

--- a/src/shell/shell-header.tsx
+++ b/src/shell/shell-header.tsx
@@ -84,12 +84,7 @@ function renderConfiguredIcon(icon: WorkspaceMenuItem['icon']): ReactNode {
 
 function renderConfiguredItem(item: WorkspaceMenuItem): ReactNode {
   const handleSelect = () => item.onClick?.();
-  const renderLink =
-    item.href != null ? (
-      <a href={item.href}>
-        <span className="sr-only">Navigate</span>
-      </a>
-    ) : undefined;
+  const renderLink = item.href != null ? <a href={item.href}>{item.label}</a> : undefined;
 
   return (
     <DropdownMenuItem

--- a/src/shell/types.ts
+++ b/src/shell/types.ts
@@ -121,17 +121,18 @@ export interface AppShellRightPanelConfig {
  * be provided; supplying both makes the item a button that fires `onClick`
  * AND navigates to `href` afterwards.
  */
-export interface WorkspaceMenuItem {
+interface WorkspaceMenuItemBase {
   id: string;
   label: ReactNode;
   icon?: LucideIcon | ReactNode;
-  href?: string;
-  onClick?: () => void;
   /** Insert a `<DropdownMenuSeparator />` immediately after this item. */
   separatorAfter?: boolean;
   /** Visual intent — `destructive` paints with the destructive token. */
   variant?: 'default' | 'destructive';
 }
+
+export type WorkspaceMenuItem = WorkspaceMenuItemBase &
+  ({ href: string; onClick?: () => void } | { onClick: () => void; href?: string });
 
 /**
  * Workspace dropdown configuration for `<AppShell variant="workspace">`.

--- a/src/shell/types.ts
+++ b/src/shell/types.ts
@@ -115,6 +115,41 @@ export interface AppShellRightPanelConfig {
   defaultView?: string;
 }
 
+/**
+ * A single configurable item in the WorkspaceSwitcher dropdown.
+ * Either `href` (renders as a link) or `onClick` (renders as a button) MUST
+ * be provided; supplying both makes the item a button that fires `onClick`
+ * AND navigates to `href` afterwards.
+ */
+export interface WorkspaceMenuItem {
+  id: string;
+  label: ReactNode;
+  icon?: LucideIcon | ReactNode;
+  href?: string;
+  onClick?: () => void;
+  /** Insert a `<DropdownMenuSeparator />` immediately after this item. */
+  separatorAfter?: boolean;
+  /** Visual intent — `destructive` paints with the destructive token. */
+  variant?: 'default' | 'destructive';
+}
+
+/**
+ * Workspace dropdown configuration for `<AppShell variant="workspace">`.
+ *
+ * When `menuItems` is provided, it REPLACES the package-default menu
+ * ("Manage workspaces", "Settings", "Profile", "Sign out"). The theme toggle
+ * is still inserted automatically by meda — between the items and the footer
+ * — so consumers don't have to reimplement theme cycling.
+ *
+ * When `menuItems` is omitted, the package defaults render unchanged (the
+ * existing 1.x behavior). This is fully additive and non-breaking.
+ */
+export interface AppShellWorkspaceConfig {
+  menuItems?: WorkspaceMenuItem[];
+  /** Extra slot rendered after all items and the theme toggle. */
+  menuFooter?: ReactNode;
+}
+
 export interface AppShellAuthConfig {
   title: ReactNode;
   description?: ReactNode;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -11,6 +11,17 @@
 
 @custom-variant dark (&:is(.dark *, [data-theme="dark"] *));
 
+@layer base {
+  :root {
+    color-scheme: light;
+  }
+
+  .dark,
+  [data-theme="dark"] {
+    color-scheme: dark;
+  }
+}
+
 @theme inline {
   /* Color primitives — exposed as Tailwind color scales */
 

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,5 +1,14 @@
 @import "./tokens.css";
 
+/* Tell Tailwind v4 to scan meda's compiled component output so utilities
+   like `h-full`, `mt-auto`, `py-3.5`, and `bg-shell-rail` (used by IconRail,
+   AppShellWorkspace, etc.) are generated even when the consumer app doesn't
+   reference them itself. Without this, consumers see broken layout where
+   meda components rely on classes the app doesn't otherwise use. Path is
+   resolved relative to this CSS file at build time, so it points to the
+   sibling component output regardless of where the package is installed. */
+@source "../**/*.js";
+
 @custom-variant dark (&:is(.dark *, [data-theme="dark"] *));
 
 @theme inline {

--- a/src/styles/theme.test.ts
+++ b/src/styles/theme.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+// Read theme.css via Node's runtime APIs without pulling in @types/node.
+// Declared locally so the package-level tsconfig (which doesn't include
+// node typings) still typechecks cleanly under jsdom Vitest runs.
+declare const require: (id: string) => unknown;
+declare const __dirname: string;
+
+const fs = require('node:fs') as { readFileSync(p: string, enc: string): string };
+const path = require('node:path') as { join(...parts: string[]): string };
+const themeCss = fs.readFileSync(path.join(__dirname, 'theme.css'), 'utf8');
+
+describe('theme.css', () => {
+  // Tailwind v4 only generates utility classes for class names it sees in
+  // scanned files. Consumer apps don't reference every utility used by meda
+  // components (e.g. `h-full`, `mt-auto`, `py-3.5`, `bg-shell-rail` on
+  // IconRail), so without an @source directive pointing at meda's compiled
+  // dist files, those classes silently disappear and component layouts
+  // collapse — most visibly, the IconRail's utility items fail to pin to
+  // the bottom of the viewport because `mt-auto` never gets generated.
+  //
+  // The directive is resolved relative to this CSS file at build time. Since
+  // src/styles/theme.css is copied verbatim to dist/styles/theme.css by the
+  // build script, `../**/*.js` from the dist location scans every emitted
+  // component module — exactly the surface consumers import from.
+  it('declares an @source directive that scans meda component output', () => {
+    expect(themeCss).toMatch(/@source\s+["']\.\.\/\*\*\/\*\.js["']/);
+  });
+});


### PR DESCRIPTION
## Release: dev → prod

Bundles four shell fixes/additions from `dev` for the next `@medalsocial/meda` publish.

### Changes

- **feat(shell): configurable WorkspaceSwitcher menu** (#80) — new `workspace.menuItems` / `menuFooter` on `<AppShell variant="workspace">`. When provided, replaces the hardcoded "Manage workspaces / Settings / Profile / Sign out" defaults; theme toggle is preserved automatically. New `WorkspaceMenuItem` (discriminated union enforcing `href` or `onClick`) and `AppShellWorkspaceConfig` types are exported.
- **fix(shell): IconRail layout via Tailwind v4 `@source`** — adds `@source "../**/*.js"` to the exported `theme.css` so consumer Tailwind v4 builds emit utility classes meda components rely on (`h-full`, `mt-auto`, `py-3.5`, `bg-shell-rail`). Fixes the IconRail collapse seen in consumer apps.
- **fix(shell): WorkspaceSwitcher link labels** (#82) — `href` items now render their configured label inside the anchor instead of an sr-only placeholder.
- **fix(theme): bind `color-scheme` to resolved app theme** (#82) — `:root { color-scheme: light }` and `.dark, [data-theme="dark"] { color-scheme: dark }`, so native UA controls follow the in-app palette rather than OS preference.
- **chore(size-limit): raise `theme.css` budget 2 kB → 2.5 kB** — accommodates the `@source` directive and `color-scheme` block (2.07 kB measured).

### Changesets

- `.changeset/feat-workspace-menu-items.md` (minor)
- `.changeset/icon-rail-tailwind-source.md` (patch)

After merge, the Changesets bot will open a Release PR (`changeset-release/prod` → `prod`) with the version bump; merging that triggers the npm publish via OIDC.
