### PR TITLE
chore(ci): pipeline optimizations and auto-merge automation

### DIFF
--- a/.changeset/ci-pipeline-optimizations.md
+++ b/.changeset/ci-pipeline-optimizations.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore(ci): pipeline optimizations and auto-merge automation. Adds `pnpm` setup-node caching across `ci`, `release`, `deploy-worker`, and `chromatic` workflows; caches Playwright Chromium browsers between runs; cancels in-progress PR runs for `ci`, `codeql`, and `chromatic` (release flow deliberately excluded so duplicate runs surface as failures); gates the Storybook build on stories/config path changes via a dedicated `storybook.yml`; collapses `size-limit` into the `build` job to remove a duplicate install + build; auto-merges the recurring dev → prod and Changesets Release PRs; and auto-opens a `prod → dev` sync PR after each release lands.

--- a/.github/workflows/auto-merge-promote-prs.yml
+++ b/.github/workflows/auto-merge-promote-prs.yml
@@ -6,7 +6,13 @@ name: Auto-merge promote PRs
 # Auto-merge waits for required status checks before merging, so this is
 # gated on the same `lint` / `test` / `build` checks as a manual merge.
 on:
-  pull_request_target:
+  # `pull_request` (not `pull_request_target`) is intentional: this workflow
+  # only ever acts on same-repo promote PRs, so it never needs base-repo
+  # context for fork PRs. With `pull_request`, fork PRs run with a read-only
+  # GITHUB_TOKEN and the `gh pr merge` write call would fail anyway — so
+  # token scope provides defense in depth alongside the same-repo `if` guard
+  # below.
+  pull_request:
     types: [opened, synchronize, reopened]
     branches: [prod]
 
@@ -17,10 +23,9 @@ permissions:
 jobs:
   enable-auto-merge:
     runs-on: ubuntu-latest
-    # Same-repo gate is critical: this workflow runs on `pull_request_target`
-    # with write permissions, so without `head.repo.full_name == repository` a
-    # fork could open a PR to `prod` from a branch named `dev` and have
-    # auto-merge enabled on it.
+    # Belt-and-braces same-repo gate even though `pull_request` already
+    # restricts the token for forks — keeps the no-op early instead of
+    # letting it fail with a 403.
     if: |
       github.event.pull_request.head.repo.full_name == github.repository &&
       (github.event.pull_request.head.ref == 'dev' ||

--- a/.github/workflows/auto-merge-promote-prs.yml
+++ b/.github/workflows/auto-merge-promote-prs.yml
@@ -1,0 +1,31 @@
+name: Auto-merge promote PRs
+
+# Enables auto-merge on the two recurring promote PRs:
+#   1. The dev → prod promotion PR (head ref `dev`).
+#   2. The Changesets-bot Release PR (head ref `changeset-release/prod`).
+# Auto-merge waits for required status checks before merging, so this is
+# gated on the same `lint` / `test` / `build` checks as a manual merge.
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches: [prod]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-auto-merge:
+    runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.head.ref == 'dev' ||
+      startsWith(github.event.pull_request.head.ref, 'changeset-release/')
+    steps:
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr merge --auto --merge \
+            --repo "${{ github.repository }}" \
+            "$PR_NUMBER"

--- a/.github/workflows/auto-merge-promote-prs.yml
+++ b/.github/workflows/auto-merge-promote-prs.yml
@@ -17,9 +17,14 @@ permissions:
 jobs:
   enable-auto-merge:
     runs-on: ubuntu-latest
+    # Same-repo gate is critical: this workflow runs on `pull_request_target`
+    # with write permissions, so without `head.repo.full_name == repository` a
+    # fork could open a PR to `prod` from a branch named `dev` and have
+    # auto-merge enabled on it.
     if: |
-      github.event.pull_request.head.ref == 'dev' ||
-      startsWith(github.event.pull_request.head.ref, 'changeset-release/')
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (github.event.pull_request.head.ref == 'dev' ||
+       startsWith(github.event.pull_request.head.ref, 'changeset-release/'))
     steps:
       - name: Enable auto-merge
         env:

--- a/.github/workflows/auto-sync-prod-to-dev.yml
+++ b/.github/workflows/auto-sync-prod-to-dev.yml
@@ -1,0 +1,77 @@
+name: Auto-sync prod → dev
+
+# After the Changesets Release PR merges to prod, the version-bump commit
+# lands on prod and dev falls behind. This workflow opens (and auto-merges)
+# a chore PR that brings dev back in sync with prod, eliminating the
+# manual merge-up step.
+#
+# Escape hatch: include `[skip auto-sync]` in the prod commit message to
+# suppress this workflow for that push.
+on:
+  push:
+    branches: [prod]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.head_commit.message, '[skip auto-sync]') }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          # Need both branches available locally to compute divergence and
+          # produce the merge.
+          ref: prod
+
+      - name: Configure git identity
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - name: Check whether prod has commits not on dev
+        id: divergence
+        run: |
+          git fetch origin dev:refs/remotes/origin/dev
+          if [ -z "$(git rev-list origin/dev..HEAD)" ]; then
+            echo "needs_sync=false" >> "$GITHUB_OUTPUT"
+            echo "prod is not ahead of dev — nothing to sync."
+          else
+            echo "needs_sync=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create sync branch and merge dev into it
+        if: steps.divergence.outputs.needs_sync == 'true'
+        id: branch
+        run: |
+          BRANCH="chore/auto-sync-prod-to-dev-${{ github.run_id }}"
+          git checkout -b "$BRANCH"
+          # Merge origin/dev into the prod-based branch so the resulting PR
+          # cleanly fast-forwards (or three-way merges) into dev.
+          git merge --no-edit origin/dev || {
+            echo "Merge conflict between prod and dev — manual intervention required."
+            exit 1
+          }
+          git push origin "$BRANCH"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Open PR and enable auto-merge
+        if: steps.divergence.outputs.needs_sync == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.branch.outputs.branch }}
+        run: |
+          PR_URL=$(gh pr create \
+            --repo "${{ github.repository }}" \
+            --base dev \
+            --head "$BRANCH" \
+            --title 'chore: auto-sync prod → dev' \
+            --body 'Automated sync after a release landed on `prod`. Brings `dev` back in line with `prod` so the next feat → dev → prod cycle starts from a clean ancestry.')
+          echo "Opened: $PR_URL"
+          gh pr merge --auto --merge \
+            --repo "${{ github.repository }}" \
+            "$PR_URL"

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   chromatic:
     name: Publish Storybook
@@ -40,6 +44,7 @@ jobs:
         if: steps.chromatic-token.outputs.available == 'true'
         with:
           node-version: '24'
+          cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile
         if: steps.chromatic-token.outputs.available == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -20,6 +24,7 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
+          cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile
 
@@ -31,6 +36,10 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    env:
+      # Pin Playwright's browser dir explicitly so the cache key matches the
+      # install location regardless of runner-image changes to $HOME defaults.
+      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.cache/ms-playwright
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -39,14 +48,31 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
+          cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile
 
+      # Cache the Playwright browser binaries (Chromium only — that's all the
+      # vitest 'storybook' project uses). Key on lockfile so a Playwright
+      # version bump invalidates automatically.
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # v3.4.3
+        with:
+          path: ${{ github.workspace }}/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
       # The vitest 'storybook' project runs every *.stories.tsx in headless
       # Chromium via @vitest/browser-playwright, so the browser binary needs
-      # to be present before `pnpm test` runs. --with-deps installs the
-      # required system libs on Ubuntu runners.
-      - run: pnpm exec playwright install chromium --with-deps
+      # to be present before `pnpm test` runs. On cache hit we only install
+      # system deps (no re-download); on miss we do the full install.
+      - name: Install Playwright Chromium (cache miss)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Install Playwright system deps only (cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps chromium
 
       - run: pnpm test
 
@@ -60,6 +86,7 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
+          cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile
 
@@ -68,41 +95,8 @@ jobs:
       - name: Validate registry
         run: pnpm registry:validate
 
-  storybook-build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: '24'
-
-      - run: pnpm install --frozen-lockfile
-
-      - run: pnpm storybook:build
-
-      - name: Upload Storybook artifact
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        with:
-          name: storybook-static
-          path: storybook-static
-          retention-days: 7
-
-  size-limit:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: '24'
-
-      - run: pnpm install --frozen-lockfile
-
-      - run: pnpm build
-
+      # size-limit runs against the freshly-built dist/, so we collapse it
+      # into the build job to avoid a duplicate `pnpm install` + `pnpm build`
+      # in a separate job. The `build` job name is preserved so the required
+      # status-check rule on dev/prod still resolves.
       - run: pnpm size-limit

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -38,6 +38,7 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
+          cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,11 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     environment: npm
+    # Pin Playwright's browser dir at the job level so every step (including
+    # the Husky pre-commit hook fired by changesets/action when it commits
+    # the version bump) resolves to the cached install location.
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.cache/ms-playwright
     # GITHUB_TOKEN gets only what the npm OIDC + provenance steps need.
     # All git/PR writes (checkout, push, PR open) use the Medal Social
     # Release Bot App token, not GITHUB_TOKEN — so contents: write and
@@ -41,15 +46,29 @@ jobs:
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+          cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile
 
-      # changesets/action stages + commits the version bump, which fires the
-      # Husky pre-commit hook (lint + test). The vitest 'storybook' project
-      # runs every *.stories.tsx in headless Chromium via @vitest/browser-
-      # playwright, so the browser binary needs to be present before that
-      # commit. --with-deps installs the required system libs on Ubuntu.
-      - run: pnpm exec playwright install chromium --with-deps
+      # Cache the Playwright browser binaries — the Husky pre-commit hook
+      # (which fires when changesets/action commits the version bump) runs
+      # `pnpm test`, and the vitest 'storybook' project drives headless
+      # Chromium via @vitest/browser-playwright. Pin PLAYWRIGHT_BROWSERS_PATH
+      # so the cache path matches the install location deterministically.
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # v3.4.3
+        with:
+          path: ${{ github.workspace }}/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install Playwright Chromium (cache miss)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Install Playwright system deps only (cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps chromium
 
       - run: pnpm build
 

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -1,0 +1,59 @@
+name: Storybook
+
+# Storybook builds are gated to changes that actually affect the Storybook
+# output — story files, .storybook/ config, or the source they render.
+# Other PRs (e.g. doc-only or workflow-only) skip this job entirely.
+on:
+  push:
+    branches: [dev, prod]
+    paths:
+      - 'src/**/*.stories.tsx'
+      - 'src/**/*.stories.ts'
+      - 'src/**/*.stories.mdx'
+      - '.storybook/**'
+      - 'src/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/storybook.yml'
+  pull_request:
+    branches: [dev, prod]
+    paths:
+      - 'src/**/*.stories.tsx'
+      - 'src/**/*.stories.ts'
+      - 'src/**/*.stories.mdx'
+      - '.storybook/**'
+      - 'src/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/storybook.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  storybook-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm storybook:build
+
+      - name: Upload Storybook artifact
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: storybook-static
+          path: storybook-static
+          retention-days: 7


### PR DESCRIPTION
## Why

Targeting a 10-minute feat → dev → prod cycle. Today CI duplicates work across jobs, never caches Playwright browsers, and two release-flow steps (merging the Release PR and syncing dev) are manual. This PR addresses all three.

## Changes

### A. CI speed (`ci.yml`, `release.yml`, `deploy-worker.yml`, `chromatic.yml`, new `storybook.yml`)

1. **pnpm store cache**: `cache: 'pnpm'` on every `actions/setup-node`. After warmup expect ~25s saved per job, ~125s across the 5 cached jobs.
2. **Playwright Chromium cache**: lockfile-keyed cache of `$GITHUB_WORKSPACE/.cache/ms-playwright` in the `test` job and `release` job. `PLAYWRIGHT_BROWSERS_PATH` is pinned at job level so the Husky pre-commit hook fired by `changesets/action` picks it up too. Cache hit runs `playwright install-deps` only (system libs, no re-download). Expect ~30–60s per affected run after warmup.
3. **Concurrency cancel-in-progress** on `ci.yml`, `codeql.yml`, `chromatic.yml`. Stops stacking duplicate runs when a PR pushes quickly.
   - **Deliberately NOT applied to `release.yml`** — release flow is stateful (npm publish, git tag, version-bump commit). A duplicate run should surface as a failure, not be silently cancelled.
4. **Storybook gated by paths**: split `storybook-build` out of `ci.yml` into its own `storybook.yml` with `paths:` filters covering `*.stories.*`, `.storybook/**`, `src/**`, lockfile, and the workflow itself. Doc-only and workflow-only PRs now skip Storybook entirely.
5. **`size-limit` collapsed into `build`**: previously `size-limit` ran its own `pnpm install` + `pnpm build`. Now `pnpm size-limit` runs after `pnpm build` in the same job. The `build` job name is preserved so the required-status-check rule still resolves.

### B. Auto-merge promote PRs (new `auto-merge-promote-prs.yml`)

Runs on `pull_request_target` to PRs targeting `prod`. If the head ref is `dev` (the dev → prod promotion PR) or `changeset-release/*` (the Changesets bot Release PR), enables `gh pr merge --auto --merge`. Auto-merge waits for required checks before merging, so the same `lint` / `test` / `build` gates apply.

### C. Auto-sync prod → dev (new `auto-sync-prod-to-dev.yml`)

Runs on push to `prod`. Computes `git rev-list dev..prod`; if non-empty, creates a branch from `prod`, merges `origin/dev` into it, pushes, opens a PR titled \`chore: auto-sync prod → dev\`, and enables auto-merge.

Escape hatch: include \`[skip auto-sync]\` in the prod commit message.

## Notes

- The auto-merge workflows depend on `bypass_pull_request_allowances` already being set on `dev`/`prod` for `alioftech` and `adaadev` (configured outside this PR).
- The `size-limit` job name disappears from PR checks — `size-limit` is not in the required-status-checks list, only `lint` / `test` / `build` are, so this is safe. Confirm OK.
- An empty changeset (`---\n---`) is included so this PR doesn't trigger a package version bump on its own.

## Test plan

- [x] All YAML files parse cleanly (validated locally with PyYAML).
- [x] `pnpm typecheck` passes.
- [x] `pnpm lint` passes (warnings only, unchanged from main).
- [x] Pre-commit hook ran successfully on commit (`pnpm lint && pnpm test && pnpm check:stories`).
- [ ] CI on this PR exercises pnpm cache, Playwright cache, concurrency, and the collapsed `build` + `size-limit` step.
- [ ] After merge to `dev`, the dev → prod promote PR will exercise the auto-merge workflow on its way to `prod`.
- [ ] Revert per file is one-liner: each workflow change is self-contained.