### PR TITLE
chore(ci): configure bot review filters for merge-up PRs

### DIFF
--- a/.github/workflows/auto-resolve-merge-up-bot-threads.yml
+++ b/.github/workflows/auto-resolve-merge-up-bot-threads.yml
@@ -7,13 +7,19 @@ name: Auto-resolve bot threads on merge-up PRs
 # auto-sync-* → dev) will block auto-merge.
 #
 # This workflow auto-resolves any unresolved review threads opened by bots on
-# those PRs once required CI checks have passed. It is intentionally narrow:
+# those PRs once the CI workflow has completed successfully. It is
+# intentionally narrow:
+#   - Only fires when CI on a same-repo PR finished with `success`
 #   - Only runs on PRs whose head ref matches the merge-up patterns
 #   - Only resolves threads opened by known bot accounts
-#   - Only fires once required checks have completed successfully
 
 on:
-  check_suite:
+  # `check_suite.completed` is unreliable here: per GitHub docs, check_suite
+  # events created by GitHub Actions do not trigger workflows, so for CI runs
+  # this event would never fire. `workflow_run` fires for any completion of a
+  # named workflow regardless of who created the check suite.
+  workflow_run:
+    workflows: ['CI']
     types: [completed]
   workflow_dispatch:
     inputs:
@@ -28,21 +34,33 @@ permissions:
 jobs:
   resolve:
     runs-on: ubuntu-latest
+    # Same-repo guard for both triggers:
+    #   - workflow_run: head_repository.full_name must match the base repo
+    #     (forks are excluded automatically because workflow_run for fork PRs
+    #     comes with the fork as the head repository).
+    #   - workflow_dispatch: re-checked inside the script via the PR's
+    #     head.repo.full_name.
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (github.event.check_suite.conclusion == 'success' &&
-       github.event.check_suite.pull_requests[0] != null)
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'pull_request' &&
+       github.event.workflow_run.head_repository.full_name == github.repository)
     steps:
       - name: Resolve bot threads on eligible PRs
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.check_suite.pull_requests[0].number }}
+          PR_NUMBER_INPUT: ${{ github.event.inputs.pr_number }}
+          # workflow_run includes pull_requests only for same-repo PRs, so
+          # pull_requests[0].number is safe here once the same-repo guard above
+          # has matched.
+          WORKFLOW_RUN_PR: ${{ github.event.workflow_run.pull_requests[0].number }}
         run: |
           set -euo pipefail
 
-          if [ -z "${PR_NUMBER:-}" ]; then
-            echo "No PR number — exiting."
+          PR_NUMBER="${PR_NUMBER_INPUT:-${WORKFLOW_RUN_PR:-}}"
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No PR number resolved from event — exiting."
             exit 0
           fi
 
@@ -51,7 +69,16 @@ jobs:
 
           PR_JSON=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")
           HEAD_REF=$(echo "$PR_JSON" | jq -r '.head.ref')
+          HEAD_REPO=$(echo "$PR_JSON" | jq -r '.head.repo.full_name')
           STATE=$(echo "$PR_JSON" | jq -r '.state')
+
+          # Hard same-repo gate. Critical for the workflow_dispatch path where
+          # an arbitrary PR number can be passed; also belt-and-braces for the
+          # workflow_run path.
+          if [ "$HEAD_REPO" != "$REPO" ]; then
+            echo "PR #${PR_NUMBER} head repo '${HEAD_REPO}' is a fork — skipping."
+            exit 0
+          fi
 
           if [ "$STATE" != "open" ]; then
             echo "PR #${PR_NUMBER} is not open (state=${STATE}) — skipping."

--- a/.github/workflows/auto-resolve-merge-up-bot-threads.yml
+++ b/.github/workflows/auto-resolve-merge-up-bot-threads.yml
@@ -95,43 +95,63 @@ jobs:
               ;;
           esac
 
-          THREADS=$(gh api graphql -f query="
-            query(\$owner: String!, \$name: String!, \$num: Int!) {
-              repository(owner: \$owner, name: \$name) {
-                pullRequest(number: \$num) {
-                  reviewThreads(first: 100) {
-                    nodes {
-                      id
-                      isResolved
-                      comments(first: 1) {
-                        nodes { author { login } }
+          BOT_LOGINS='chatgpt-codex-connector qodo-code-review github-actions copilot'
+
+          # Paginate through all review threads. GitHub caps `first` at 100, so
+          # large PRs can carry leftover bot threads on subsequent pages that
+          # would otherwise still block merge under required_conversation_resolution.
+          CURSOR=""
+          while :; do
+            if [ -z "$CURSOR" ]; then
+              AFTER_ARG=""
+            else
+              AFTER_ARG="-f cursor=$CURSOR"
+            fi
+
+            # shellcheck disable=SC2086
+            PAGE=$(gh api graphql $AFTER_ARG -f query="
+              query(\$owner: String!, \$name: String!, \$num: Int!, \$cursor: String) {
+                repository(owner: \$owner, name: \$name) {
+                  pullRequest(number: \$num) {
+                    reviewThreads(first: 100, after: \$cursor) {
+                      pageInfo { hasNextPage endCursor }
+                      nodes {
+                        id
+                        isResolved
+                        comments(first: 1) {
+                          nodes { author { login } }
+                        }
                       }
                     }
                   }
                 }
-              }
-            }" -f owner="$OWNER" -f name="$NAME" -F num="$PR_NUMBER")
+              }" -f owner="$OWNER" -f name="$NAME" -F num="$PR_NUMBER")
 
-          BOT_LOGINS='chatgpt-codex-connector qodo-code-review github-actions copilot'
-
-          echo "$THREADS" | jq -r '
-            .data.repository.pullRequest.reviewThreads.nodes[]
-            | select(.isResolved == false)
-            | "\(.id) \(.comments.nodes[0].author.login)"
-          ' | while IFS=' ' read -r thread_id author; do
-            stripped="${author%\[bot\]}"
-            for bot in $BOT_LOGINS; do
-              if [ "$stripped" = "$bot" ]; then
-                echo "Resolving thread ${thread_id} from ${author}"
-                gh api graphql -f query='
-                  mutation($id: ID!) {
-                    resolveReviewThread(input: {threadId: $id}) {
-                      thread { id isResolved }
-                    }
-                  }' -f id="$thread_id" >/dev/null
-                break
-              fi
+            echo "$PAGE" | jq -r '
+              .data.repository.pullRequest.reviewThreads.nodes[]
+              | select(.isResolved == false)
+              | "\(.id) \(.comments.nodes[0].author.login)"
+            ' | while IFS=' ' read -r thread_id author; do
+              stripped="${author%\[bot\]}"
+              for bot in $BOT_LOGINS; do
+                if [ "$stripped" = "$bot" ]; then
+                  echo "Resolving thread ${thread_id} from ${author}"
+                  gh api graphql -f query='
+                    mutation($id: ID!) {
+                      resolveReviewThread(input: {threadId: $id}) {
+                        thread { id isResolved }
+                      }
+                    }' -f id="$thread_id" >/dev/null
+                  break
+                fi
+              done
             done
+
+            HAS_NEXT=$(echo "$PAGE" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')
+            if [ "$HAS_NEXT" != "true" ]; then
+              break
+            fi
+            CURSOR=$(echo "$PAGE" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor')
           done
 
           echo "Done."

--- a/.github/workflows/auto-resolve-merge-up-bot-threads.yml
+++ b/.github/workflows/auto-resolve-merge-up-bot-threads.yml
@@ -1,0 +1,110 @@
+name: Auto-resolve bot threads on merge-up PRs
+
+# Codex (chatgpt-codex-connector) does not honor branch-based skip rules — it
+# only respects AGENTS.md "Review guidelines" as a soft signal. Combined with
+# `required_conversation_resolution: true` on the prod branch, an unresolved
+# Codex thread on a merge-up PR (dev → prod, changeset-release/* → prod,
+# auto-sync-* → dev) will block auto-merge.
+#
+# This workflow auto-resolves any unresolved review threads opened by bots on
+# those PRs once required CI checks have passed. It is intentionally narrow:
+#   - Only runs on PRs whose head ref matches the merge-up patterns
+#   - Only resolves threads opened by known bot accounts
+#   - Only fires once required checks have completed successfully
+
+on:
+  check_suite:
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to process'
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.check_suite.conclusion == 'success' &&
+       github.event.check_suite.pull_requests[0] != null)
+    steps:
+      - name: Resolve bot threads on eligible PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.check_suite.pull_requests[0].number }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${PR_NUMBER:-}" ]; then
+            echo "No PR number — exiting."
+            exit 0
+          fi
+
+          OWNER="${REPO%/*}"
+          NAME="${REPO#*/}"
+
+          PR_JSON=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")
+          HEAD_REF=$(echo "$PR_JSON" | jq -r '.head.ref')
+          STATE=$(echo "$PR_JSON" | jq -r '.state')
+
+          if [ "$STATE" != "open" ]; then
+            echo "PR #${PR_NUMBER} is not open (state=${STATE}) — skipping."
+            exit 0
+          fi
+
+          case "$HEAD_REF" in
+            dev|changeset-release/*|chore/auto-sync-*)
+              echo "PR #${PR_NUMBER} head ref '${HEAD_REF}' is a merge-up PR — proceeding."
+              ;;
+            *)
+              echo "PR #${PR_NUMBER} head ref '${HEAD_REF}' is not a merge-up PR — skipping."
+              exit 0
+              ;;
+          esac
+
+          THREADS=$(gh api graphql -f query="
+            query(\$owner: String!, \$name: String!, \$num: Int!) {
+              repository(owner: \$owner, name: \$name) {
+                pullRequest(number: \$num) {
+                  reviewThreads(first: 100) {
+                    nodes {
+                      id
+                      isResolved
+                      comments(first: 1) {
+                        nodes { author { login } }
+                      }
+                    }
+                  }
+                }
+              }
+            }" -f owner="$OWNER" -f name="$NAME" -F num="$PR_NUMBER")
+
+          BOT_LOGINS='chatgpt-codex-connector qodo-code-review github-actions copilot'
+
+          echo "$THREADS" | jq -r '
+            .data.repository.pullRequest.reviewThreads.nodes[]
+            | select(.isResolved == false)
+            | "\(.id) \(.comments.nodes[0].author.login)"
+          ' | while IFS=' ' read -r thread_id author; do
+            stripped="${author%\[bot\]}"
+            for bot in $BOT_LOGINS; do
+              if [ "$stripped" = "$bot" ]; then
+                echo "Resolving thread ${thread_id} from ${author}"
+                gh api graphql -f query='
+                  mutation($id: ID!) {
+                    resolveReviewThread(input: {threadId: $id}) {
+                      thread { id isResolved }
+                    }
+                  }' -f id="$thread_id" >/dev/null
+                break
+              fi
+            done
+          done
+
+          echo "Done."

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,17 @@
+# Qodo Merge / qodo-code-review configuration.
+# https://qodo-merge-docs.qodo.ai/usage-guide/additional_configurations/
+
+[config]
+# Skip Qodo review on merge-up PRs. The code on these PRs has already been
+# reviewed at the feat → dev stage; re-reviewing on the promote PRs is noise
+# that delays the release flow with stale findings.
+#
+# Patterns are regex against the source (head) branch name:
+#   - `^dev$`                    → the dev → prod release PR
+#   - `^changeset-release/.*$`   → the Changesets bot's "Release PR"
+#   - `^chore/auto-sync-.*$`     → the prod → dev auto-sync PR
+ignore_pr_source_branches = [
+  "^dev$",
+  "^changeset-release/.*$",
+  "^chore/auto-sync-.*$",
+]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,17 @@
 # @medalsocial/meda
 
 See [CLAUDE.md](./CLAUDE.md) for the contributor and agent guide.
+
+## Review guidelines
+
+These guidelines apply to automated code review (e.g. ChatGPT Codex Connector).
+
+### Skip merge-up PRs
+
+Do not flag issues on PRs whose head branch is `dev`, matches `changeset-release/*`,
+or matches `chore/auto-sync-*`. These are merge-up / release-promotion PRs that
+re-package code already reviewed at the feat → dev stage. Re-reviewing them
+produces stale, duplicate findings that block the release flow.
+
+If the PR was opened against `prod` from one of those branches, treat it as
+already reviewed and skip.


### PR DESCRIPTION
## Why

PR #80's bot reviews surfaced **after** it was merged into `dev`, on the `dev → prod` promote PR (#83), forcing splits into PR #81, #82, #86 — each its own CI cycle. The same code got reviewed multiple times. This blocks the 10-min feat→prod target.

## What

Three layers, narrow in scope:

1. **`.pr_agent.toml`** — Qodo Merge config. Uses `ignore_pr_source_branches` regex to skip Qodo entirely on:
   - `^dev$` (the dev → prod release PR)
   - `^changeset-release/.*$` (the Changesets bot's Release PR)
   - `^chore/auto-sync-.*$` (the prod → dev auto-sync PR from PR #88)

2. **`AGENTS.md`** — ChatGPT Codex Connector reads this as a soft signal. Adds a "Review guidelines" section asking Codex to skip the same merge-up patterns. Codex doesn't expose a hard branch filter, so this is best-effort.

3. **`.github/workflows/auto-resolve-merge-up-bot-threads.yml`** — safety net. Triggers on \`check_suite: completed\` (success). On a merge-up PR, finds any unresolved review threads opened by known bots (\`chatgpt-codex-connector\`, \`qodo-code-review\`, \`github-actions\`, \`copilot\`) and resolves them via GraphQL \`resolveReviewThread\`. Combined with \`required_conversation_resolution: true\` on \`dev\`/\`prod\`, this stops auto-merge from stalling on a thread Codex still managed to file.

## How this fits the broader plan

Pairs with PR #88 (CI speed + auto-merge promote PRs + auto-sync prod→dev). Together: feat PR is reviewed once at feat→dev, then promote PRs glide through with auto-merge once CI is green.

## Test plan

- TOML and YAML both validated by parser locally.
- Qodo reads \`.pr_agent.toml\` from the default branch (\`prod\`), so the filter only takes effect after this PR ships through the dev → prod chain.
- Auto-resolve workflow only fires on \`check_suite.completed\` with success, scoped to merge-up branch patterns and known bot logins. Worst case is a no-op.