### PR TITLE
fix(ci): use Medal Approvals app token to enable auto-merge

### DIFF
--- a/.github/workflows/auto-merge-promote-prs.yml
+++ b/.github/workflows/auto-merge-promote-prs.yml
@@ -16,9 +16,14 @@ on:
     types: [opened, synchronize, reopened]
     branches: [prod]
 
-permissions:
-  contents: write
-  pull-requests: write
+# GITHUB_TOKEN is left at zero perms — the actual write call uses the
+# Medal Approvals App token minted in the job. Auto-merge enabled by the
+# default `GITHUB_TOKEN` causes the eventual merge push to be attributed
+# to `github-actions[bot]`, and per GitHub's docs events triggered by
+# `GITHUB_TOKEN` do NOT cascade to other workflows. That silently breaks
+# the post-merge chain (Auto-sync prod → dev, Release, Deploy Worker, …).
+# A GitHub App token does NOT have that limitation, so we mint one.
+permissions: {}
 
 jobs:
   enable-auto-merge:
@@ -30,10 +35,18 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       (github.event.pull_request.head.ref == 'dev' ||
        startsWith(github.event.pull_request.head.ref, 'changeset-release/'))
+    permissions: {}
     steps:
+      - name: Generate Medal Approvals token
+        id: app-token
+        uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b # v2.1.4
+        with:
+          app-id: ${{ secrets.MEDAL_APPROVALS_APP_ID }}
+          private-key: ${{ secrets.MEDAL_APPROVALS_PRIVATE_KEY }}
+
       - name: Enable auto-merge
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           gh pr merge --auto --merge \


### PR DESCRIPTION
## Why

Live test on PR #96 exposed a final gotcha in the auto-merge chain: when auto-merge is enabled via the default \`GITHUB_TOKEN\`, the resulting merge push is attributed to \`github-actions[bot]\`, and per [GitHub's docs](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) **events triggered by \`GITHUB_TOKEN\` do not create new workflow runs** (with two narrow exceptions). That silently broke the post-merge chain after #96 — Release, Auto-sync prod → dev, Deploy Worker, Storybook all skipped, only CodeQL fired (it has its own \`dynamic\` trigger).

## What

\`auto-merge-promote-prs.yml\` now mints a Medal Approvals App token (same App that \`auto-approve.yml\` already uses) and passes it to \`gh pr merge --auto --merge\`. App-token-attributed events DO cascade to downstream workflows.

## Security

- App token is scoped per-installation; no scope expansion.
- \`permissions: {}\` at workflow + job level (default \`GITHUB_TOKEN\` left zero-rights — only the App token has merge-write).
- Same-repo guard already in place for the \`if:\` condition.
- \`pull_request\` (not \`pull_request_target\`) — workflow never has secret-rich base-repo context against fork code.

## Verifies

After this lands and a dev → prod cycle runs, the merge of the dev → prod PR should fire all push-event workflows (CI, Release, Deploy Worker, Storybook, Auto-sync prod → dev) — not just CodeQL.