### PR TITLE
Release: dev → prod (app token for auto-merge)

### DIFF
--- a/.github/workflows/auto-merge-promote-prs.yml
+++ b/.github/workflows/auto-merge-promote-prs.yml
@@ -16,9 +16,14 @@ on:
     types: [opened, synchronize, reopened]
     branches: [prod]
 
-permissions:
-  contents: write
-  pull-requests: write
+# GITHUB_TOKEN is left at zero perms — the actual write call uses the
+# Medal Approvals App token minted in the job. Auto-merge enabled by the
+# default `GITHUB_TOKEN` causes the eventual merge push to be attributed
+# to `github-actions[bot]`, and per GitHub's docs events triggered by
+# `GITHUB_TOKEN` do NOT cascade to other workflows. That silently breaks
+# the post-merge chain (Auto-sync prod → dev, Release, Deploy Worker, …).
+# A GitHub App token does NOT have that limitation, so we mint one.
+permissions: {}
 
 jobs:
   enable-auto-merge:
@@ -30,10 +35,18 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       (github.event.pull_request.head.ref == 'dev' ||
        startsWith(github.event.pull_request.head.ref, 'changeset-release/'))
+    permissions: {}
     steps:
+      - name: Generate Medal Approvals token
+        id: app-token
+        uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b # v2.1.4
+        with:
+          app-id: ${{ secrets.MEDAL_APPROVALS_APP_ID }}
+          private-key: ${{ secrets.MEDAL_APPROVALS_PRIVATE_KEY }}
+
       - name: Enable auto-merge
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           gh pr merge --auto --merge \


### PR DESCRIPTION
Final piece of the chain. With this on prod, the auto-merge workflow will use the Medal Approvals App token, which means downstream push-triggered workflows (Auto-sync, Release, Deploy Worker) will fire after the merge — fixing the gotcha exposed by PR #96.