### PR TITLE
Release: dev → prod (full chain validation)

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -8,7 +8,7 @@ name: Auto-approve trusted PRs
 #
 # Covered today:
 #   - changeset-release/* PRs opened by Changesets bots         (Release PR)
-#   - chore/auto-sync-* PRs opened by github-actions[bot]       (auto-sync prod → dev)
+#   - chore/auto-sync-* PRs opened by medal-approvals[bot]      (auto-sync prod → dev)
 #   - dev → prod PRs opened by trusted maintainer humans        (release promote)
 #
 # NOT covered (intentionally):
@@ -47,8 +47,8 @@ jobs:
       (
         (
           github.event.pull_request.user.type == 'Bot' &&
-          contains(fromJson('["medal-social-release-bot[bot]", "changeset-bot[bot]", "github-actions[bot]"]'), github.event.pull_request.user.login) &&
-          contains(fromJson('["medal-social-release-bot[bot]", "changeset-bot[bot]", "github-actions[bot]"]'), github.actor) &&
+          contains(fromJson('["medal-social-release-bot[bot]", "changeset-bot[bot]", "medal-approvals[bot]"]'), github.event.pull_request.user.login) &&
+          contains(fromJson('["medal-social-release-bot[bot]", "changeset-bot[bot]", "medal-approvals[bot]"]'), github.actor) &&
           (
             startsWith(github.event.pull_request.head.ref, 'changeset-release/') ||
             startsWith(github.event.pull_request.head.ref, 'chore/auto-sync-')

--- a/.github/workflows/auto-sync-prod-to-dev.yml
+++ b/.github/workflows/auto-sync-prod-to-dev.yml
@@ -12,26 +12,43 @@ on:
     branches: [prod]
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
+# GITHUB_TOKEN is left at zero perms — write actions use the Medal
+# Approvals App token minted in the job. Using GITHUB_TOKEN to open the
+# sync PR (and to push the sync branch) caused the resulting events to be
+# attributed to `github-actions[bot]`, and per GitHub's docs events
+# triggered by GITHUB_TOKEN do NOT cascade to other workflows. That
+# silently broke the chain: the sync PR was created but auto-approve and
+# auto-merge-promote-prs.yml never fired, leaving the PR stuck on
+# REVIEW_REQUIRED indefinitely.
+permissions: {}
 
 jobs:
   sync:
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.head_commit.message, '[skip auto-sync]') }}
+    permissions: {}
     steps:
+      - name: Generate Medal Approvals token
+        id: app-token
+        uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b # v2.1.4
+        with:
+          app-id: ${{ secrets.MEDAL_APPROVALS_APP_ID }}
+          private-key: ${{ secrets.MEDAL_APPROVALS_PRIVATE_KEY }}
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           # Need both branches available locally to compute divergence and
           # produce the merge.
           ref: prod
+          # Use App token so the push that creates the sync branch comes
+          # from the App identity (which DOES trigger downstream workflows).
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Configure git identity
         run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git config user.name 'medal-approvals[bot]'
+          git config user.email 'medal-approvals[bot]@users.noreply.github.com'
 
       - name: Check whether prod has commits not on dev
         id: divergence
@@ -62,7 +79,7 @@ jobs:
       - name: Open PR and enable auto-merge
         if: steps.divergence.outputs.needs_sync == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           BRANCH: ${{ steps.branch.outputs.branch }}
         run: |
           PR_URL=$(gh pr create \


### PR DESCRIPTION
Final end-to-end test. With PR #101 on dev, this PR exercises the full hands-off chain: auto-approve + auto-merge on this PR via Medal Approvals App token; downstream Auto-sync and Release workflows fire after merge; the auto-sync PR opens via Medal Approvals App token so it triggers auto-approve + auto-merge in turn; everything chains. Zero manual clicks expected.