### PR TITLE
Fix PR110 mobile drawer review issue

### DIFF
--- a/dist/shell/internal/mobile-drawers.js
+++ b/dist/shell/internal/mobile-drawers.js
@@ -75,7 +75,7 @@ function renderWorkspaceIcon(icon) {
     if (typeof icon === 'function') {
         return createElement(icon, { size: 18, 'aria-hidden': true });
     }
-    if (typeof icon === 'object' && icon !== null) {
+    if (typeof icon === 'object') {
         const candidate = icon;
         if (candidate.$$typeof != null) {
             return createElement(icon, { size: 18, 'aria-hidden': true });

--- a/src/shell/internal/mobile-drawers.tsx
+++ b/src/shell/internal/mobile-drawers.tsx
@@ -255,7 +255,7 @@ function renderWorkspaceIcon(icon: WorkspaceMenuItem['icon']): ReactNode {
   if (typeof icon === 'function') {
     return createElement(icon as LucideIcon, { size: 18, 'aria-hidden': true });
   }
-  if (typeof icon === 'object' && icon !== null) {
+  if (typeof icon === 'object') {
     const candidate = icon as unknown as { $$typeof?: symbol };
     if (candidate.$$typeof != null) {
       return createElement(icon as unknown as LucideIcon, { size: 18, 'aria-hidden': true });


### PR DESCRIPTION
## Summary
- Remove redundant null comparison in mobile workspace icon rendering
- Regenerate built mobile drawer output

## Verification
- pnpm exec biome check src/shell/internal/mobile-drawers.tsx
- pnpm exec vitest run --environment jsdom src/shell/app-shell-workspace.test.tsx
- pnpm build
- pnpm test
- git diff --check