### PR TITLE
Exclude release cache from Biome

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -6,6 +6,7 @@
       "!**/dist",
       "!**/demo/dist",
       "!**/node_modules",
+      "!**/.cache",
       "!**/coverage",
       "!**/registry/r",
       "!**/storybook-static",


### PR DESCRIPTION
## Summary
- Exclude `.cache` from Biome file discovery so Release job commit hooks do not lint cached Playwright browser files.

## Why
The prod Release workflow failed after PR #110 because `changesets/action` created a version commit and the commit hook ran `biome check .` against `.cache/ms-playwright` files restored inside the checkout.

## Verification
- `pnpm exec biome check biome.json`
- `.cache/biome-ignore-test/bad.js` probe is ignored by Biome
- `pnpm lint`
- `pnpm build`
- `pnpm test`
- `git diff --check`