### PR TITLE
feat(marketing): data-driven mega-menu (nav features) + MarketingShell banner slot

### DIFF
--- a/.changeset/medalsocial-com-header-unification.md
+++ b/.changeset/medalsocial-com-header-unification.md
@@ -1,0 +1,5 @@
+---
+"@medalsocial/meda": minor
+---
+
+feat(marketing): nav `features` shorthand on `MarketingNavMenuItem` (auto-renders `MarketingMegaMenu` when no explicit `panel`) and a `banner` slot on `MarketingShell`. Enables fully data-driven, Sanity-fed marketing headers.

--- a/src/marketing/marketing-header.tsx
+++ b/src/marketing/marketing-header.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { type ReactNode, useState } from 'react';
+import { MarketingMegaMenu } from './marketing-mega-menu.js';
 import { MarketingNavItem } from './marketing-nav-item.js';
 import type { MarketingHeaderProps } from './types.js';
 import { cx } from './utils.js';
@@ -69,7 +70,21 @@ export function MarketingHeader({
   }
 
   const activeItem = navItems.find((i) => i.id === openId);
-  const activePanel = activeItem && 'panel' in activeItem ? activeItem.panel : undefined;
+  let activePanel: ReactNode;
+  if (activeItem && 'panel' in activeItem && activeItem.panel) {
+    activePanel = activeItem.panel;
+  } else if (activeItem && 'features' in activeItem && activeItem.features) {
+    activePanel = (
+      <MarketingMegaMenu
+        triggerId={activeItem.id}
+        open
+        onOpenChange={(next) => setOpenId(next ? activeItem.id : null)}
+        features={activeItem.features}
+      />
+    );
+  } else {
+    activePanel = undefined;
+  }
 
   return (
     <nav aria-label="Primary" className="relative" onMouseLeave={() => setOpenId(null)}>

--- a/src/marketing/marketing-shell.tsx
+++ b/src/marketing/marketing-shell.tsx
@@ -1,9 +1,16 @@
 import type { MarketingShellProps } from './types.js';
 import { cx } from './utils.js';
 
-export function MarketingShell({ header, footer, children, className }: MarketingShellProps) {
+export function MarketingShell({
+  banner,
+  header,
+  footer,
+  children,
+  className,
+}: MarketingShellProps) {
   return (
     <div className={cx('flex min-h-screen flex-col bg-background text-foreground', className)}>
+      {banner && <div className="w-full">{banner}</div>}
       {header && <header className="sticky top-4 z-40 px-4 sm:px-6">{header}</header>}
       <main className="flex-1">{children}</main>
       {footer && <footer className="mt-auto">{footer}</footer>}

--- a/src/marketing/types.ts
+++ b/src/marketing/types.ts
@@ -121,6 +121,7 @@ export interface MarketingHeaderProps {
 }
 
 export interface MarketingShellProps {
+  banner?: ReactNode;
   header?: ReactNode;
   footer?: ReactNode;
   children?: ReactNode;

--- a/src/marketing/types.ts
+++ b/src/marketing/types.ts
@@ -100,6 +100,8 @@ export interface MarketingNavMenuItem extends MarketingNavItemBase {
   hasMenu: true;
   href?: string;
   panel?: ReactNode;
+  /** Data-driven mega-menu. Rendered via MarketingMegaMenu when `panel` is not provided. */
+  features?: MarketingMegaMenuFeature[];
 }
 
 export type MarketingNavItemDescriptor = MarketingNavLinkItem | MarketingNavMenuItem;

--- a/test/unit/marketing/marketing-header.test.tsx
+++ b/test/unit/marketing/marketing-header.test.tsx
@@ -1,8 +1,6 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
 import { MarketingHeader } from '../../../src/marketing/marketing-header.js';
-
-afterEach(cleanup);
 
 describe('MarketingHeader', () => {
   it('renders Sign in + Start free when no user', () => {

--- a/test/unit/marketing/marketing-header.test.tsx
+++ b/test/unit/marketing/marketing-header.test.tsx
@@ -1,6 +1,8 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
 import { MarketingHeader } from '../../../src/marketing/marketing-header.js';
+
+afterEach(cleanup);
 
 describe('MarketingHeader', () => {
   it('renders Sign in + Start free when no user', () => {
@@ -75,5 +77,52 @@ describe('MarketingHeader', () => {
     expect(screen.getByTestId('products-panel')).toBeInTheDocument();
     fireEvent.click(trigger);
     expect(screen.queryByTestId('products-panel')).toBeNull();
+  });
+});
+
+describe('MarketingHeader features-driven mega menu', () => {
+  it('renders a MarketingMegaMenu from features when the item is opened', () => {
+    render(
+      <MarketingHeader
+        navItems={[
+          {
+            id: 'products',
+            label: 'Products',
+            hasMenu: true,
+            features: [
+              {
+                id: 'composer',
+                title: 'AI Composer',
+                description: 'Draft',
+                href: '/products/composer',
+              },
+            ],
+          },
+        ]}
+      />
+    );
+    expect(screen.queryByText('AI Composer')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Products' }));
+    const link = screen.getByRole('link', { name: /AI Composer/ });
+    expect(link).toHaveAttribute('href', '/products/composer');
+  });
+
+  it('prefers an explicit panel over features', () => {
+    render(
+      <MarketingHeader
+        navItems={[
+          {
+            id: 'x',
+            label: 'X',
+            hasMenu: true,
+            panel: <div data-testid="explicit-panel">explicit</div>,
+            features: [{ id: 'a', title: 'A', href: '/a' }],
+          },
+        ]}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'X' }));
+    expect(screen.getByTestId('explicit-panel')).toBeInTheDocument();
+    expect(screen.queryByText('A')).not.toBeInTheDocument();
   });
 });

--- a/test/unit/marketing/marketing-shell.test.tsx
+++ b/test/unit/marketing/marketing-shell.test.tsx
@@ -31,3 +31,29 @@ describe('MarketingShell', () => {
     expect(screen.getByRole('banner')).toBeInTheDocument();
   });
 });
+
+describe('MarketingShell banner slot', () => {
+  it('renders a banner above the header when provided', () => {
+    render(
+      <MarketingShell
+        banner={<div data-testid="banner">Announcement</div>}
+        header={<div data-testid="header">Header</div>}
+      >
+        <p>body</p>
+      </MarketingShell>
+    );
+    const banner = screen.getByTestId('banner');
+    const header = screen.getByTestId('header');
+    expect(banner).toBeInTheDocument();
+    expect(banner.compareDocumentPosition(header) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('omits the banner wrapper when no banner is passed', () => {
+    render(
+      <MarketingShell header={<div>Header</div>}>
+        <p>body</p>
+      </MarketingShell>
+    );
+    expect(screen.queryByTestId('banner')).not.toBeInTheDocument();
+  });
+});

--- a/test/unit/marketing/types.test.ts
+++ b/test/unit/marketing/types.test.ts
@@ -10,6 +10,7 @@ describe('MarketingNavMenuItem features shorthand', () => {
       features: [{ id: 'a', title: 'A', href: '/a' }],
     };
     expect(item.hasMenu).toBe(true);
-    expect('features' in item && item.features?.[0]?.href).toBe('/a');
+    expect('features' in item).toBe(true);
+    expect(item.features?.[0]?.href).toBe('/a');
   });
 });

--- a/test/unit/marketing/types.test.ts
+++ b/test/unit/marketing/types.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import type { MarketingNavItemDescriptor } from '../../../src/marketing/types.js';
+
+describe('MarketingNavMenuItem features shorthand', () => {
+  it('accepts a features array on a menu item', () => {
+    const item: MarketingNavItemDescriptor = {
+      id: 'products',
+      label: 'Products',
+      hasMenu: true,
+      features: [{ id: 'a', title: 'A', href: '/a' }],
+    };
+    expect(item.hasMenu).toBe(true);
+    expect('features' in item && item.features?.[0]?.href).toBe('/a');
+  });
+});


### PR DESCRIPTION
## Summary

Extends `@medalsocial/meda/marketing` so consumers can drive the header from data instead of hand-built JSX:

- **`MarketingNavMenuItem.features?`** — a `MarketingMegaMenuFeature[]` shorthand. `MarketingHeader` auto-renders `MarketingMegaMenu` from `features` when an item has no explicit `panel` (explicit `panel` still wins).
- **`MarketingShell` `banner?` slot** — renders an announcement region above the header as part of the shell contract.
- Changeset added (`minor`).

Enables fully Sanity-fed marketing headers (consumed by medalsocial-com — see the paired medal-customers PR).

## Test plan

- [x] `pnpm test` — 1565/1565 pass (incl. new `test/unit/marketing/{types,marketing-header,marketing-shell}.test.tsx`)
- [x] `pnpm typecheck` clean
- [x] `pnpm build` — marketing entrypoints emit
- [ ] Reviewer: confirm `features` shorthand + explicit-`panel` precedence; banner slot ordering