### PR TITLE
feat(shell): IconRail section dividers

### DIFF
--- a/.changeset/icon-rail-section-divider.md
+++ b/.changeset/icon-rail-section-divider.md
@@ -1,0 +1,5 @@
+---
+"@medalsocial/meda": minor
+---
+
+IconRail: support non-interactive section dividers via `{ kind: 'divider', id }` entries in mainItems/utilityItems (backward-compatible).

--- a/src/shell/app-shell-workspace.tsx
+++ b/src/shell/app-shell-workspace.tsx
@@ -3,6 +3,7 @@ import { LayoutGrid, Menu, PanelTop, Sparkles } from 'lucide-react';
 import { type ReactNode, useContext } from 'react';
 import { CommandPalette, CommandRegistryContext } from './command-palette.js';
 import { ContextRail } from './context-rail.js';
+import type { IconRailEntry, IconRailItem } from './icon-rail.js';
 import { IconRail } from './icon-rail.js';
 import { MobileBottomNav } from './internal/mobile-bottom-nav.js';
 import { MobileDrawers } from './internal/mobile-drawers.js';
@@ -67,7 +68,13 @@ export function AppShellWorkspace({
   // shows both, so dropping utilityItems here would orphan items like Help/
   // Settings on mobile. Concat preserves discoverability; visual separation
   // (divider in the drawer between main and utility) is a future polish.
-  const mobileMenuItems = iconRail ? [...iconRail.mainItems, ...(iconRail.utilityItems ?? [])] : [];
+  // Non-interactive section dividers are desktop-rail-only — filter them out
+  // and narrow back to navigable IconRailItem[] for the mobile drawer.
+  const mobileMenuItems: IconRailItem[] = iconRail
+    ? [...iconRail.mainItems, ...(iconRail.utilityItems ?? [])].filter(
+        (e: IconRailEntry): e is IconRailItem => !('kind' in e && e.kind === 'divider')
+      )
+    : [];
 
   // ONE tree shape across both viewports. ShellMain stays at a fixed position
   // in its parent's children array so React preserves its subtree (and the

--- a/src/shell/app-shell.stories.tsx
+++ b/src/shell/app-shell.stories.tsx
@@ -37,6 +37,7 @@ const APPS: AppDefinition[] = [
 const RAIL_MAIN = [
   { id: 'inbox', label: 'Inbox', to: '/inbox', icon: Inbox },
   { id: 'calendar', label: 'Calendar', to: '/calendar', icon: Calendar },
+  { kind: 'divider', id: 'testing' },
   { id: 'users', label: 'People', to: '/people', icon: Users },
 ];
 const RAIL_UTILITY = [{ id: 'help', label: 'Help', to: '/help', icon: HelpCircle }];

--- a/src/shell/icon-rail.tsx
+++ b/src/shell/icon-rail.tsx
@@ -25,6 +25,23 @@ export interface IconRailItem {
   badge?: ReactNode;
 }
 
+/**
+ * A non-interactive section separator placed inline within `mainItems` or
+ * `utilityItems`. Renders a hairline rule — no tooltip, no link, no icon box
+ * — and never matches `activeId`. Additive: `IconRailItem` has no `kind`
+ * field, so existing `IconRailItem[]` consumers stay valid.
+ */
+export interface IconRailDivider {
+  kind: 'divider';
+  id: string;
+}
+
+export type IconRailEntry = IconRailItem | IconRailDivider;
+
+function isDivider(entry: IconRailEntry): entry is IconRailDivider {
+  return 'kind' in entry && entry.kind === 'divider';
+}
+
 export interface IconRailRenderLinkArgs {
   item: IconRailItem;
   isActive: boolean;
@@ -34,8 +51,8 @@ export interface IconRailRenderLinkArgs {
 }
 
 export interface IconRailProps {
-  mainItems: IconRailItem[];
-  utilityItems?: IconRailItem[];
+  mainItems: IconRailEntry[];
+  utilityItems?: IconRailEntry[];
   footer?: ReactNode;
   activeId?: string;
   renderLink?: (args: IconRailRenderLinkArgs) => ReactNode;
@@ -104,7 +121,21 @@ export function IconRail({
 
   if (band === 'mobile') return null;
 
-  const renderItem = (item: IconRailItem) => {
+  const renderItem = (entry: IconRailEntry) => {
+    if (isDivider(entry)) {
+      // <hr> is the semantic separator — implicit ARIA role="separator", so
+      // no explicit role attr (biome a11y forbids the redundant role on
+      // <hr>). Non-interactive: no tooltip, no link, never matches activeId.
+      return (
+        <hr
+          key={entry.id}
+          data-testid={`icon-rail-divider-${entry.id}`}
+          className="my-1.5 h-px w-5 border-0 bg-border"
+        />
+      );
+    }
+
+    const item = entry;
     const isActive = item.id === activeId;
     const klass = itemClass(isActive);
     const IconComp = item.icon;

--- a/src/shell/types.ts
+++ b/src/shell/types.ts
@@ -115,8 +115,8 @@ export type AppShellVariant = 'auth' | 'workspace' | 'chat';
 
 /** IconRail configuration for `<AppShell variant="workspace">`. */
 export interface AppShellIconRailConfig {
-  mainItems: import('./icon-rail.js').IconRailItem[];
-  utilityItems?: import('./icon-rail.js').IconRailItem[];
+  mainItems: import('./icon-rail.js').IconRailEntry[];
+  utilityItems?: import('./icon-rail.js').IconRailEntry[];
   footer?: ReactNode;
   activeId?: string;
   renderLink?: import('./icon-rail.js').IconRailProps['renderLink'];

--- a/test/unit/shell/icon-rail.test.tsx
+++ b/test/unit/shell/icon-rail.test.tsx
@@ -3,7 +3,7 @@ import { act, fireEvent, render, screen } from '@testing-library/react';
 import { Inbox, Settings } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { IconRailItem } from '../../../src/shell/icon-rail.js';
+import type { IconRailEntry, IconRailItem } from '../../../src/shell/icon-rail.js';
 import { IconRail } from '../../../src/shell/icon-rail.js';
 import { MedaShellProvider } from '../../../src/shell/shell-provider.js';
 import type { AppDefinition, WorkspaceDefinition } from '../../../src/shell/types.js';
@@ -220,6 +220,157 @@ describe('IconRail', () => {
     );
 
     expect(screen.queryByTestId('rail-divider')).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — IconRail dividers (non-interactive section separators)
+// ---------------------------------------------------------------------------
+
+describe('IconRail dividers', () => {
+  it('renders a separator element with role and testid for a divider entry', () => {
+    render(
+      <Wrapper>
+        <IconRail
+          mainItems={[
+            { id: 'inbox', label: 'Inbox', to: '/inbox', icon: Inbox },
+            { kind: 'divider', id: 'testing' },
+            { id: 'settings', label: 'Settings', to: '/settings', icon: Settings },
+          ]}
+        />
+      </Wrapper>
+    );
+
+    const divider = screen.getByTestId('icon-rail-divider-testing');
+    expect(divider).toBeInTheDocument();
+    // <hr> carries the implicit ARIA role "separator"
+    expect(divider.tagName).toBe('HR');
+    expect(screen.getByRole('separator')).toBe(divider);
+  });
+
+  it('does not wrap a divider in a tooltip trigger', () => {
+    render(
+      <Wrapper>
+        <IconRail
+          mainItems={[
+            { id: 'inbox', label: 'Inbox', to: '/inbox', icon: Inbox },
+            { kind: 'divider', id: 'testing' },
+          ]}
+        />
+      </Wrapper>
+    );
+
+    expect(screen.queryByTestId('icon-rail-trigger-testing')).not.toBeInTheDocument();
+    expect(screen.getByTestId('icon-rail-trigger-inbox')).toBeInTheDocument();
+  });
+
+  it('never invokes renderLink for a divider entry', () => {
+    const renderLink = vi.fn(({ item, children }) => (
+      <span data-testid={`link-${item.id}`}>{children}</span>
+    ));
+
+    render(
+      <Wrapper>
+        <IconRail
+          mainItems={[
+            { id: 'inbox', label: 'Inbox', to: '/inbox', icon: Inbox },
+            { kind: 'divider', id: 'testing' },
+            { id: 'settings', label: 'Settings', to: '/settings', icon: Settings },
+          ]}
+        />
+      </Wrapper>
+    );
+
+    expect(renderLink).not.toHaveBeenCalled();
+
+    render(
+      <Wrapper>
+        <IconRail
+          mainItems={[
+            { id: 'inbox', label: 'Inbox', to: '/inbox', icon: Inbox },
+            { kind: 'divider', id: 'testing' },
+            { id: 'settings', label: 'Settings', to: '/settings', icon: Settings },
+          ]}
+          renderLink={renderLink}
+        />
+      </Wrapper>
+    );
+
+    expect(renderLink).toHaveBeenCalledTimes(2);
+    for (const call of renderLink.mock.calls) {
+      expect(call[0].item.id).not.toBe('testing');
+    }
+  });
+
+  it('divider never receives active styling even when activeId matches its id', () => {
+    render(
+      <Wrapper>
+        <IconRail
+          mainItems={[
+            { id: 'inbox', label: 'Inbox', to: '/inbox', icon: Inbox },
+            { kind: 'divider', id: 'testing' },
+          ]}
+          activeId="testing"
+        />
+      </Wrapper>
+    );
+
+    const divider = screen.getByTestId('icon-rail-divider-testing');
+    expect(divider.tagName).toBe('HR');
+    expect(screen.getByRole('separator')).toBe(divider);
+    expect(divider.className).not.toContain('bg-primary');
+  });
+
+  it('preserves order — separator sits between the two item triggers', () => {
+    render(
+      <Wrapper>
+        <IconRail
+          mainItems={[
+            { id: 'inbox', label: 'Inbox', to: '/inbox', icon: Inbox },
+            { kind: 'divider', id: 'testing' },
+            { id: 'settings', label: 'Settings', to: '/settings', icon: Settings },
+          ]}
+        />
+      </Wrapper>
+    );
+
+    const itemA = screen.getByTestId('icon-rail-trigger-inbox');
+    const divider = screen.getByTestId('icon-rail-divider-testing');
+    const itemB = screen.getByTestId('icon-rail-trigger-settings');
+
+    expect(itemA.compareDocumentPosition(divider) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(divider.compareDocumentPosition(itemB) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('back-compat: a plain IconRailItem[] (no kind) renders exactly as before', () => {
+    const plain: IconRailItem[] = [
+      { id: 'inbox', label: 'Inbox', to: '/inbox', icon: Inbox },
+      { id: 'settings', label: 'Settings', to: '/settings', icon: Settings },
+    ];
+    render(
+      <Wrapper>
+        <IconRail mainItems={plain} />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('icon-rail-trigger-inbox')).toBeInTheDocument();
+    expect(screen.getByTestId('icon-rail-trigger-settings')).toBeInTheDocument();
+    expect(screen.queryByRole('separator')).not.toBeInTheDocument();
+  });
+
+  it('renders dividers placed in utilityItems too', () => {
+    const utility: IconRailEntry[] = [
+      { kind: 'divider', id: 'util-sep' },
+      { id: 'help', label: 'Help', to: '/help', icon: Settings },
+    ];
+    render(
+      <Wrapper>
+        <IconRail mainItems={mainItems} utilityItems={utility} />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('icon-rail-divider-util-sep')).toBeInTheDocument();
+    expect(screen.getByTestId('icon-rail-trigger-help')).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary

Additive `IconRailDivider` entry type for `IconRail` `mainItems` / `utilityItems`.

- New `IconRailDivider` (`{ kind: 'divider'; id: string }`) and `IconRailEntry = IconRailItem | IconRailDivider` types, exported from `src/shell/icon-rail.tsx`. `IconRailProps.mainItems`/`utilityItems` and `AppShellIconRailConfig.mainItems`/`utilityItems` widened to `IconRailEntry[]`.
- **Backward-compatible**: `IconRailItem` has no `kind` field, so existing `IconRailItem[]` consumers stay valid — no item rendering changed for non-divider entries. Minor version bump via changeset.
- Divider renders a plain hairline rule (`<hr class="my-1.5 h-px w-5 border-0 bg-border">`), no label/tooltip/link/icon box, and never matches `activeId`. Works in both `mainItems` and `utilityItems`.
- **Excluded from mobile menu**: the mobile drawer flatten in `app-shell-workspace.tsx` filters divider entries out and narrows back to `IconRailItem[]`; mobile menu is unaffected (dividers are desktop-rail-only by design).
- Storybook `RAIL_MAIN` fixture gets a divider between two items so Chromatic snapshots the new visual.

## Implementation note (design adaptation)

The design specified `<div role="separator">`. The repo's biome a11y ruleset (`useSemanticElements` / `useFocusableInteractive` / `useAriaPropsForRole` / `noRedundantRoles`) rejects an explicit `role="separator"` on a `<div>` and on `<hr>`. Implemented as a semantic `<hr>` (implicit ARIA `role="separator"`), which is more accessible and lint-clean while fully honoring the design intent (non-interactive section separator, same `data-testid="icon-rail-divider-<id>"`, same hairline visual). Divider tests assert the implicit separator role via `getByRole('separator')` + `tagName === 'HR'`.

## Test plan

- [x] TDD: 7 new divider tests written first (red), then implementation (green)
- [x] Full unit suite: 219 files / 1567 tests passing
- [x] Typecheck clean (`tsc -p tsconfig.build.json --noEmit`)
- [x] `biome check` clean (1 pre-existing unrelated warning in marketing-mega-menu.stories.tsx)
- [x] `check:stories` clean
- [ ] Chromatic visual review of updated `RAIL_MAIN` story

## Consumer follow-up

medal-labs `pr-dashboard` will insert `{ kind: 'divider', id: 'testing' }` between Initiatives and Journeys after a meda release.