### PR TITLE
release: shell mobile chrome + panel-views + context-rail seam (2.5.0)

### DIFF
--- a/.changeset/shell-mobile-and-panel-views.md
+++ b/.changeset/shell-mobile-and-panel-views.md
@@ -1,0 +1,21 @@
+---
+"@medalsocial/meda": minor
+---
+
+feat(shell): mobile-first chrome, grouped panel-views dropdown, unified context-rail seam, and borderless header.
+
+App shell additions and refinements (all additive / backwards-compatible):
+
+- **`headerLeading` slot** — new optional left-region content rendered right after the `WorkspaceSwitcher` (spacing only, no divider). Threaded through `AppShell` (workspace variant), `AppShellWorkspace`, and `ShellHeader`. On mobile it surfaces inside the menu drawer as horizontally-scrolling section tabs.
+- **Grouped panel-views dropdown** — `PanelToggle` now accepts `panelViews` and renders a single grouped pill (panel icon + chevron) that opens a dropdown of registered views; selecting the open view closes the panel, selecting another focuses it. With no views it stays a plain open/close toggle. `ShellHeader` gains `showPanelToggle` + `panelViews`; the workspace shell wires them from the resolved right-panel views.
+- **Borderless unified header** — removed the `border-b` from `ShellHeader` and the mobile header; header height grows to 64px with a new 48px `--shell-mobile-header-height` token. `headerCenter` now lays the desktop header out as a 3-column grid.
+- **Mobile header workspace switcher** — the root mobile header workspace identity is now a button that opens the menu drawer (`mobileDrawer.setOpen('menu-drawer')`), accepts and centers `headerCenter` (e.g. a clock), and uses `bg-background`.
+- **Mobile drawers** — menu drawer renders `sectionTabs` (fed from `headerLeading`) and auto-closes on anchor click; module drawer gains `moduleActiveItemId` + `moduleRenderLink` for active-state and router-link parity with the desktop context rail.
+- **Unified context-rail seam** — the separate resize handle and collapse pull-tab are merged into one `group/seam` element: a single brand-tinted seam line (revealed on rail hover / grip focus) that resizes via pointer drag, with a collapse/expand grip pill. The rail's right border is now hover-only (removed the always-on `border-r`). The collapse grip remains the keyboard-accessible control.
+- **Icon rail `labelVisibility`** — new `'tooltip' | 'visible'` prop; `'visible'` renders a wider labelled rail (`--shell-rail-label-width`) with an icon frame and inline label, active items use a solid `bg-primary` treatment.
+- **`svh` viewport units** — workspace/chat chrome and `AppShellBody` switch from `100vh`/`h-screen` to `100svh`/`h-svh` so mobile browser chrome doesn't clip the layout.
+- **Opt out of the built-in command palette** — new `builtInCommandPalette` prop on the workspace `AppShell`/`AppShellWorkspace` (default `true`, so the auto-mounted `CommandPalette` + `CommandRegistryContext` is preserved — fully backwards-compatible). Host apps that ship their own palette set `builtInCommandPalette={false}` to avoid a duplicate empty dialog.
+- **`workflow-builder` CSS** — `@xyflow/react/dist/style.css` is imported once from the package stylesheet (`@medalsocial/meda/styles`) instead of from the canvas component module, so the styles are bundled with the theme rather than re-imported per consumer build.
+- Dropped `[content-visibility:auto]` from `ShellMain` (it interfered with measured/sticky children).
+
+New public types: `IconRailLabelVisibility`, `PanelToggleProps`; new config fields `AppShellIconRailConfig.labelVisibility` and `AppShellContextRailConfig.renderLink`.

--- a/biome.json
+++ b/biome.json
@@ -3,6 +3,7 @@
   "files": {
     "includes": [
       "**",
+      "!**/.worktrees",
       "!**/dist",
       "!**/demo/dist",
       "!**/node_modules",

--- a/src/shell/app-shell-workspace.tsx
+++ b/src/shell/app-shell-workspace.tsx
@@ -33,9 +33,17 @@ export interface AppShellWorkspaceProps {
   appTabs?: AppShellAppTabsConfig;
   globalActions?: ReactNode;
   headerCenter?: ReactNode;
+  headerLeading?: ReactNode;
   banners?: ReactNode;
   mainLayout?: ShellMainLayout;
   mainClassName?: string;
+  /**
+   * Whether to render the built-in `CommandPalette` (providing the
+   * `CommandRegistryContext`) when no registry is already in context. Defaults
+   * to `true` for backwards compatibility; set `false` to opt out when the host
+   * app ships its own palette.
+   */
+  builtInCommandPalette?: boolean;
   children: ReactNode;
 }
 
@@ -47,9 +55,11 @@ export function AppShellWorkspace({
   appTabs,
   globalActions,
   headerCenter,
+  headerLeading,
   banners,
   mainLayout,
   mainClassName,
+  builtInCommandPalette = true,
   children,
 }: AppShellWorkspaceProps) {
   const viewport = useShellViewport();
@@ -80,16 +90,19 @@ export function AppShellWorkspace({
   // nested viewport-height divs collapse cleanly — no double-scroll.
   const commandRegistry = useContext(CommandRegistryContext);
   const shell = (
-    <div className="flex h-screen flex-col">
+    <div className="flex h-svh flex-col">
       {isMobile ? (
-        <MobileHeader globalActions={globalActions} />
+        <MobileHeader globalActions={globalActions} headerCenter={headerCenter} />
       ) : (
         <ShellHeader
           globalActions={globalActions}
           headerCenter={headerCenter}
+          headerLeading={headerLeading}
           appTabsRenderLink={appTabs?.renderLink}
           workspaceMenuItems={workspace?.menuItems}
           workspaceMenuFooter={workspace?.menuFooter}
+          showPanelToggle={resolvedRightPanel.panelViews.length > 0}
+          panelViews={resolvedRightPanel.panelViews}
         />
       )}
       {banners ? (
@@ -107,6 +120,7 @@ export function AppShellWorkspace({
             footer={iconRail.footer}
             activeId={iconRail.activeId}
             renderLink={iconRail.renderLink}
+            labelVisibility={iconRail.labelVisibility}
           />
         )}
         {!isMobile && contextRail && (
@@ -114,6 +128,7 @@ export function AppShellWorkspace({
             appId={contextRail.appId}
             module={contextRail.module}
             activeItemId={contextRail.activeItemId}
+            renderLink={contextRail.renderLink}
             header={contextRail.header}
             scroll={contextRail.scroll}
           />
@@ -135,8 +150,11 @@ export function AppShellWorkspace({
           workspaceMenuFooter={workspace?.menuFooter}
           module={contextRail?.module}
           moduleAppId={contextRail?.appId}
+          moduleActiveItemId={contextRail?.activeItemId}
+          moduleRenderLink={contextRail?.renderLink}
           moduleHeader={contextRail?.header}
           moduleScroll={contextRail?.scroll}
+          sectionTabs={headerLeading}
           panelViews={resolvedRightPanel.panelViews}
           defaultView={resolvedRightPanel.defaultView}
         />
@@ -144,7 +162,16 @@ export function AppShellWorkspace({
     </div>
   );
 
-  return commandRegistry ? shell : <CommandPalette>{shell}</CommandPalette>;
+  // Backwards-compatible default: meda provides the built-in CommandPalette
+  // (and its CommandRegistryContext) so consumers calling useCommands()/
+  // useCommandGroup() under the workspace shell keep working. When a registry is
+  // already present, or the consumer opts out via builtInCommandPalette={false}
+  // (e.g. apps that ship their own palette), render the bare shell to avoid a
+  // duplicate dialog.
+  if (commandRegistry || !builtInCommandPalette) {
+    return shell;
+  }
+  return <CommandPalette>{shell}</CommandPalette>;
 }
 
 function buildMobileNavItems(

--- a/src/shell/app-shell.tsx
+++ b/src/shell/app-shell.tsx
@@ -54,6 +54,11 @@ export type AppShellProps = AppShellBaseProps &
          */
         headerCenter?: ReactNode;
         /**
+         * Optional leading content rendered in the LEFT header region immediately
+         * after the workspace switcher. On mobile, surfaced inside the menu drawer.
+         */
+        headerLeading?: ReactNode;
+        /**
          * Optional chrome-level content rendered below the header and above
          * the workspace rail row.
          */
@@ -67,6 +72,13 @@ export type AppShellProps = AppShellBaseProps &
          * Optional className for the workspace shell's main scroll region.
          */
         mainClassName?: string;
+        /**
+         * Whether meda renders its built-in `CommandPalette` (and provides the
+         * `CommandRegistryContext`) when no command registry is already present.
+         * Defaults to `true` for backwards compatibility. Set `false` when the
+         * host app ships its own command palette to avoid a duplicate dialog.
+         */
+        builtInCommandPalette?: boolean;
       }
     | {
         variant: 'chat';
@@ -80,7 +92,7 @@ export function AppShell(props: AppShellProps) {
   // Auth lets the form scroll past viewport (signup, dense forms, high zoom);
   // workspace and chat fix the chrome to viewport height and let inner regions
   // scroll independently.
-  const heightClass = props.variant === 'auth' ? 'min-h-screen' : 'h-screen overflow-hidden';
+  const heightClass = props.variant === 'auth' ? 'min-h-screen' : 'h-svh overflow-hidden';
 
   const wrapper = (content: ReactNode) => (
     <div
@@ -106,9 +118,11 @@ export function AppShell(props: AppShellProps) {
           appTabs={props.appTabs}
           globalActions={props.globalActions}
           headerCenter={props.headerCenter}
+          headerLeading={props.headerLeading}
           banners={props.banners}
           mainLayout={props.mainLayout}
           mainClassName={props.mainClassName}
+          builtInCommandPalette={props.builtInCommandPalette}
         >
           {props.children}
         </AppShellWorkspace>
@@ -138,7 +152,7 @@ export function AppShellBody({ children, className }: { children: ReactNode; cla
   return (
     <div
       className={cn(
-        'relative flex h-[calc(100vh-var(--shell-header-height))] overflow-hidden',
+        'relative flex h-[calc(100svh-var(--shell-header-height))] overflow-hidden',
         className
       )}
     >

--- a/src/shell/context-rail.tsx
+++ b/src/shell/context-rail.tsx
@@ -15,7 +15,7 @@
  * once <AppShellBody> ships as a ResizableShell Group.
  */
 
-import { PanelLeftClose, PanelLeftOpen } from 'lucide-react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
 import type { AnchorHTMLAttributes, ReactNode, PointerEvent as ReactPointerEvent } from 'react';
 import { Fragment, useId, useRef, useState } from 'react';
 import { cn } from '../lib/utils.js';
@@ -57,21 +57,28 @@ export interface ContextRailProps {
 }
 
 // ---------------------------------------------------------------------------
-// ResizeHandle — right-edge drag handle (Pattern B)
+// ContextRailSeam — the single seam handle at the rail's right boundary. It is
+// both the drag-to-resize separator AND the collapse grip, so there is exactly
+// ONE highlight line: dragging the seam resizes, clicking the grip collapses.
 // ---------------------------------------------------------------------------
 
-interface ResizeHandleProps {
+interface ContextRailSeamProps {
+  railId: string;
   currentWidth: number;
   onResize: (w: number) => void;
   onCommit: (w: number) => void;
 }
 
-function ResizeHandle({ currentWidth, onResize, onCommit }: ResizeHandleProps) {
+function ContextRailSeam({ railId, currentWidth, onResize, onCommit }: ContextRailSeamProps) {
+  const ctx = useMedaShell();
+  const collapsed = ctx.contextRail.collapsed;
+  const Icon = collapsed ? ChevronRight : ChevronLeft;
   const startWidthRef = useRef(currentWidth);
   const startXRef = useRef(0);
   const draggingRef = useRef(false);
 
   const handlePointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
+    if (collapsed) return; // no resize while collapsed
     // setPointerCapture may not be available in all test environments (jsdom)
     try {
       e.currentTarget.setPointerCapture(e.pointerId);
@@ -102,61 +109,74 @@ function ResizeHandle({ currentWidth, onResize, onCommit }: ResizeHandleProps) {
     onCommit(next);
   };
 
+  // Grip reveal: invisible until the rail is hovered (expanded); faint and
+  // reachable when collapsed so the rail can always be reopened.
+  const reveal = collapsed
+    ? 'pointer-events-auto opacity-55'
+    : 'pointer-events-none opacity-0 group-hover/seam:pointer-events-auto group-hover/seam:opacity-100';
+
+  // ONE element: a full-height col-resize separator straddling the boundary,
+  // carrying the single seam line (brand + glow on hover/focus) and the grip
+  // pill. Dragging the seam resizes; clicking the grip (which stops pointer
+  // propagation) collapses — no separate resize handle, so only one line.
   return (
-    // biome-ignore lint/a11y/useSemanticElements: <hr> can't accept pointer events; div with role="separator" is the correct pattern here
+    // Outer wrapper: positioning + pointer-driven resize. It is NOT itself a
+    // widget role — the `separator` role lives on the thin seam line below and
+    // the collapse grip is a sibling button, so no interactive roles nest
+    // (avoids axe `nested-interactive`). One `group/seam` scope still drives the
+    // shared hover/focus reveal for both the line and the grip.
+    // biome-ignore lint/a11y/noStaticElementInteractions: pointer-only resize affordance; the keyboard-accessible control is the grip <button> sibling
     <div
-      role="separator"
-      aria-orientation="vertical"
-      aria-label="Resize context rail"
-      aria-valuenow={currentWidth}
-      aria-valuemin={MIN_WIDTH}
-      aria-valuemax={MAX_WIDTH}
-      tabIndex={0}
-      className={cn(
-        'absolute top-0 right-0 h-full w-1 cursor-col-resize',
-        'opacity-0 transition-opacity hover:opacity-100 hover:bg-ring'
-      )}
+      data-testid="context-rail-seam"
+      data-collapsed={collapsed ? 'true' : 'false'}
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}
       onPointerUp={handlePointerUp}
-    />
-  );
-}
-
-// ---------------------------------------------------------------------------
-// ContextRailToggle — chevron button that flips ctx.contextRail.collapsed
-// ---------------------------------------------------------------------------
-
-function ContextRailToggle({ railId }: { railId: string }) {
-  const ctx = useMedaShell();
-  const collapsed = ctx.contextRail.collapsed;
-  // Lucide PanelLeft* icons render the chevron-with-wall pattern (similar
-  // to Unifi). The wall reinforces "this is a sidebar toggle" rather than
-  // a generic navigation chevron.
-  const Icon = collapsed ? PanelLeftOpen : PanelLeftClose;
-  return (
-    <button
-      type="button"
-      onClick={() => ctx.contextRail.setCollapsed(!collapsed)}
-      aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-      aria-expanded={!collapsed}
-      aria-controls={railId}
-      data-testid="context-rail-toggle"
       className={cn(
-        // Pull-tab: 28w × 40h. Big enough to read the icon at a glance and to
-        // grab confidently — matches Unifi's reference. Flat left edge
-        // attached to the rail (no left border), rounded right. The whole tab
-        // sticks fully out of the rail's outer edge.
-        'absolute top-3 -right-7 z-20 inline-flex h-10 w-7 items-center justify-center',
-        'before:absolute before:-inset-1 before:content-[""]',
-        'rounded-r-md border border-l-0 border-border bg-card text-muted-foreground',
-        'shadow-[2px_0_4px_rgb(0_0_0_/_0.08)]',
-        'hover:bg-accent hover:text-foreground',
-        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+        'group/seam absolute top-0 right-0 bottom-0 z-20 w-3 translate-x-1/2',
+        collapsed ? 'cursor-default' : 'cursor-col-resize'
       )}
     >
-      <Icon size={18} aria-hidden />
-    </button>
+      {/* single seam line — carries the resize separator semantics; brand + glow
+          on rail hover or grip focus, faint when collapsed */}
+      {/* biome-ignore lint/a11y/useSemanticElements: <hr> can't carry the live resize value semantics; a span with role="separator" is the correct pattern */}
+      {/* biome-ignore lint/a11y/useFocusableInteractive: the separator exposes the resize value to AT but is operated via pointer; the focusable keyboard control is the sibling grip <button> (keeping the separator out of the tab order avoids an axe nested-interactive violation) */}
+      <span
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize context rail"
+        aria-valuenow={currentWidth}
+        aria-valuemin={MIN_WIDTH}
+        aria-valuemax={MAX_WIDTH}
+        className={cn(
+          'pointer-events-none absolute inset-y-0 left-1/2 w-[2px] -translate-x-1/2 transition-[background-color,box-shadow] duration-150',
+          collapsed ? 'bg-shell-border' : 'bg-transparent',
+          'group-hover/seam:bg-[var(--color-brand-400)] group-hover/seam:shadow-[0_0_14px_-1px_var(--color-brand-400)]',
+          'group-focus-visible/seam:bg-[var(--color-brand-400)] group-focus-visible/seam:shadow-[0_0_14px_-1px_var(--color-brand-400)]'
+        )}
+      />
+      {/* grip pill — collapse/expand; stops propagation so grabbing it never starts a resize drag */}
+      <button
+        type="button"
+        onPointerDown={(e) => e.stopPropagation()}
+        onClick={() => ctx.contextRail.setCollapsed(!collapsed)}
+        aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+        aria-expanded={!collapsed}
+        aria-controls={railId}
+        data-testid="context-rail-toggle"
+        className={cn(
+          'absolute top-1/2 left-1/2 grid h-12 w-[21px] -translate-x-1/2 -translate-y-1/2 place-items-center rounded-full border bg-card text-[var(--color-brand-400)]',
+          'border-[color-mix(in_oklab,var(--color-brand-400)_26%,transparent)]',
+          'transition-[opacity,transform,box-shadow,border-color] duration-150',
+          collapsed ? 'scale-90' : 'scale-[.82]',
+          reveal,
+          'group-hover/seam:scale-100 group-hover/seam:border-[var(--color-brand-400)] group-hover/seam:opacity-100 group-hover/seam:shadow-[0_6px_18px_-4px_color-mix(in_oklab,var(--color-brand-400)_65%,transparent)]',
+          'focus-visible:scale-100 focus-visible:border-[var(--color-brand-400)] focus-visible:opacity-100 focus-visible:outline-none focus-visible:shadow-[0_0_0_3px_color-mix(in_oklab,var(--color-brand-400)_35%,transparent)]'
+        )}
+      >
+        <Icon size={14} aria-hidden />
+      </button>
+    </div>
   );
 }
 
@@ -226,19 +246,25 @@ export function ContextRail({
       data-testid="context-rail"
       aria-label={module.label}
       className={cn(
-        'relative h-full shrink-0 border-r border-shell-border bg-shell-context',
+        'group/rail relative h-full shrink-0 bg-shell-context',
         !isDragging && 'transition-[width] duration-200 ease-in-out motion-reduce:transition-none',
         collapsed && 'w-0',
         className
       )}
       style={{ width: collapsed ? 0 : width }}
     >
-      {/* Toggle: absolute, sits half on the rail's right edge. Stays visible
-          even when the inner content shrinks to width 0 — when collapsed, the
-          outer aside is also w-0 and the toggle anchors at the IconRail's
-          right edge by virtue of -right-2.5. Skipped when collapsible={false}
-          so consumers opting out of the collapse behavior get a fixed rail. */}
-      {collapsible && <ContextRailToggle railId={railId} />}
+      {/* Unified seam at the right boundary: drag-to-resize AND collapse grip,
+          so there is exactly one highlight line. The seam line + grip reveal on
+          rail hover (group/seam). Skipped when collapsible={false} so consumers
+          opting out of the collapse behavior get a fixed rail. */}
+      {collapsible && (
+        <ContextRailSeam
+          railId={railId}
+          currentWidth={width}
+          onResize={handleResize}
+          onCommit={handleCommit}
+        />
+      )}
 
       {/* Inner overflow wrapper so the rail content clips cleanly during the
           width animation without clipping the absolute toggle above.
@@ -315,11 +341,6 @@ export function ContextRail({
           {module.render?.({ workspaceId: ctx.workspace.id, appId })}
         </div>
       </div>
-
-      {/* Right-edge resize handle — only when expanded (no rail edge to grab when collapsed) */}
-      {!collapsed && (
-        <ResizeHandle currentWidth={width} onResize={handleResize} onCommit={handleCommit} />
-      )}
     </aside>
   );
 }

--- a/src/shell/icon-rail.tsx
+++ b/src/shell/icon-rail.tsx
@@ -3,7 +3,7 @@
 import type { LucideIcon } from 'lucide-react';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import type { AnchorHTMLAttributes, ReactNode } from 'react';
-import { useState } from 'react';
+import { Fragment, useState } from 'react';
 import {
   Tooltip,
   TooltipContent,
@@ -33,12 +33,15 @@ export interface IconRailRenderLinkArgs {
   linkProps: AnchorHTMLAttributes<HTMLAnchorElement>;
 }
 
+export type IconRailLabelVisibility = 'tooltip' | 'visible';
+
 export interface IconRailProps {
   mainItems: IconRailItem[];
   utilityItems?: IconRailItem[];
   footer?: ReactNode;
   activeId?: string;
   renderLink?: (args: IconRailRenderLinkArgs) => ReactNode;
+  labelVisibility?: IconRailLabelVisibility;
   className?: string;
 }
 
@@ -46,12 +49,37 @@ export interface IconRailProps {
 // Item styling
 // ---------------------------------------------------------------------------
 
-function itemClass(isActive: boolean) {
+function itemClass(isActive: boolean, labelVisibility: IconRailLabelVisibility) {
+  if (labelVisibility === 'visible') {
+    return cn(
+      'group relative flex min-h-[4rem] w-full flex-col items-center justify-start gap-1 px-1 py-1 text-center transition-colors',
+      isActive ? 'text-foreground' : 'text-muted-foreground hover:text-foreground'
+    );
+  }
   return cn(
     'group relative flex h-11 w-11 items-center justify-center rounded-xl transition-colors',
     isActive
-      ? 'bg-primary/12 text-primary'
+      ? 'bg-primary text-primary-foreground shadow-sm ring-2 ring-primary/60'
       : 'text-muted-foreground hover:bg-accent hover:text-foreground'
+  );
+}
+
+function iconFrameClass(isActive: boolean) {
+  return cn(
+    'relative inline-flex h-11 w-11 items-center justify-center rounded-xl transition-colors',
+    isActive
+      ? 'bg-primary text-primary-foreground shadow-sm ring-2 ring-primary/60'
+      : 'group-hover:bg-accent group-hover:text-foreground'
+  );
+}
+
+function railClass(labelVisibility: IconRailLabelVisibility, className?: string) {
+  return cn(
+    'flex h-full shrink-0 flex-col items-center bg-shell-rail',
+    labelVisibility === 'visible'
+      ? 'w-[var(--shell-rail-label-width)] px-2 py-4'
+      : 'w-[var(--shell-rail-width)] py-3.5',
+    className
   );
 }
 
@@ -97,6 +125,7 @@ export function IconRail({
   footer,
   activeId,
   renderLink,
+  labelVisibility = 'tooltip',
   className,
 }: IconRailProps) {
   const band = useShellViewport();
@@ -104,11 +133,23 @@ export function IconRail({
 
   if (band === 'mobile') return null;
 
+  const showLabels = labelVisibility === 'visible';
+
   const renderItem = (item: IconRailItem) => {
     const isActive = item.id === activeId;
-    const klass = itemClass(isActive);
+    const klass = itemClass(isActive, labelVisibility);
     const IconComp = item.icon;
-    const inner = (
+    const inner = showLabels ? (
+      <>
+        <span data-slot="icon-rail-icon-frame" className={iconFrameClass(isActive)}>
+          <IconComp size={26} aria-hidden="true" />
+          {item.badge ? <span className="absolute right-1 top-1">{item.badge}</span> : null}
+        </span>
+        <span data-slot="icon-rail-label" className="max-w-full truncate text-[12px] leading-4">
+          {item.label}
+        </span>
+      </>
+    ) : (
       <>
         <IconComp size={22} aria-hidden="true" />
         {item.badge ? <span className="absolute right-1 top-1">{item.badge}</span> : null}
@@ -130,16 +171,20 @@ export function IconRail({
       <a {...linkProps} />
     );
 
+    const trigger = (
+      <span data-testid={`icon-rail-trigger-${item.id}`} className={klass}>
+        {linkContent}
+      </span>
+    );
+
+    if (showLabels) {
+      return <Fragment key={item.id}>{trigger}</Fragment>;
+    }
+
     return (
       <Tooltip key={item.id}>
         {/* Trigger span owns the visual state; link inside provides navigation. */}
-        <TooltipTrigger
-          render={
-            <span data-testid={`icon-rail-trigger-${item.id}`} className={klass}>
-              {linkContent}
-            </span>
-          }
-        />
+        <TooltipTrigger render={trigger} />
         <TooltipContent side="right">{item.label}</TooltipContent>
       </Tooltip>
     );
@@ -150,12 +195,11 @@ export function IconRail({
       <nav
         data-testid="icon-rail"
         aria-label="Primary"
-        className={cn(
-          'flex h-full w-[var(--shell-rail-width)] shrink-0 flex-col items-center bg-shell-rail py-3.5',
-          className
-        )}
+        className={railClass(labelVisibility, className)}
       >
-        <div className="flex flex-col items-center gap-1">{mainItems.map(renderItem)}</div>
+        <div className={cn('flex flex-col items-center', showLabels ? 'w-full gap-1' : 'gap-1')}>
+          {mainItems.map(renderItem)}
+        </div>
         {utilityItems.length > 0 && (
           <>
             <RailDivider
@@ -164,7 +208,11 @@ export function IconRail({
             />
             <div
               data-testid="utility-items-wrapper"
-              className={cn('flex flex-col items-center gap-1', pinnedBottom && 'mt-auto')}
+              className={cn(
+                'flex flex-col items-center',
+                showLabels ? 'w-full gap-1' : 'gap-1',
+                pinnedBottom && 'mt-auto'
+              )}
             >
               {utilityItems.map(renderItem)}
             </div>

--- a/src/shell/index.ts
+++ b/src/shell/index.ts
@@ -30,7 +30,12 @@ export { DragModeBanner } from './drag-mode-banner.js';
 // Extras (legacy components ported during Phase 15 — opt-in for apps that need them)
 export * as Extras from './extras/index.js';
 // Rails + main + panel
-export type { IconRailItem, IconRailProps, IconRailRenderLinkArgs } from './icon-rail.js';
+export type {
+  IconRailItem,
+  IconRailLabelVisibility,
+  IconRailProps,
+  IconRailRenderLinkArgs,
+} from './icon-rail.js';
 export { IconRail, RailDivider } from './icon-rail.js';
 export type { ShellStorageAdapter } from './layout-state.js';
 // Storage adapter (consumers may want to provide their own)
@@ -47,7 +52,7 @@ export { RailDropZones } from './rail-drop-zones.js';
 export { ResizableHandle, ResizableShell, ResizableShellPanel } from './resizable-shell.js';
 export { RightPanel } from './right-panel.js';
 // Header (and its individual children for advanced composition)
-export type { AppTabsProps } from './shell-header.js';
+export type { AppTabsProps, PanelToggleProps } from './shell-header.js';
 export { AppTabs, PanelToggle, ShellHeader, WorkspaceSwitcher } from './shell-header.js';
 export { ShellMain } from './shell-main.js';
 export type { MedaShellProviderProps } from './shell-provider.js';

--- a/src/shell/internal/mobile-bottom-nav.tsx
+++ b/src/shell/internal/mobile-bottom-nav.tsx
@@ -43,7 +43,7 @@ export function MobileBottomNav({ items, className }: MobileBottomNavProps) {
       data-testid="mobile-bottom-nav"
       aria-label="Mobile navigation"
       className={cn(
-        'flex h-[var(--shell-bottom-nav-height)] items-center justify-around border-t border-border bg-card',
+        'flex h-[calc(var(--shell-bottom-nav-height)+env(safe-area-inset-bottom))] items-start justify-around border-t border-border bg-card px-1 pb-[env(safe-area-inset-bottom)]',
         className
       )}
     >
@@ -119,10 +119,10 @@ function MobileBottomNavButton({ item }: { item: MobileBottomNavItem }) {
       onPointerCancel={handlePointerCancel}
       onClick={handleClick}
       aria-label={label}
-      className="flex h-full flex-1 flex-col items-center justify-center gap-0.5 text-muted-foreground hover:text-foreground"
+      className="flex h-[var(--shell-bottom-nav-height)] flex-1 flex-col items-center justify-center gap-0.5 rounded-xl px-1 text-muted-foreground transition-colors hover:text-foreground active:bg-accent"
     >
       <Icon size={20} aria-hidden="true" />
-      <span className="text-[10px]">{label}</span>
+      <span className="font-medium text-[10px] leading-none">{label}</span>
     </button>
   );
 }

--- a/src/shell/internal/mobile-drawers.tsx
+++ b/src/shell/internal/mobile-drawers.tsx
@@ -19,6 +19,7 @@ import {
   DrawerTitle,
 } from '../../components/ui/drawer.js';
 import { cn } from '../../lib/utils.js';
+import type { ContextRailProps } from '../context-rail.js';
 import type { IconRailItem, IconRailProps } from '../icon-rail.js';
 import { useMedaShell } from '../shell-provider.js';
 import { useTheme } from '../theme.js';
@@ -46,10 +47,19 @@ export interface MobileDrawersProps {
   module?: ContextModule;
   /** App id used when rendering module custom content. */
   moduleAppId?: string;
+  /** Active module item id, sourced from context rail config. */
+  moduleActiveItemId?: string;
+  /** Custom module link renderer, sourced from context rail config. */
+  moduleRenderLink?: ContextRailProps['renderLink'];
   /** Header behavior mirrored from the desktop ContextRail. */
   moduleHeader?: ContextRailHeader;
   /** Scroll behavior mirrored from the desktop ContextRail. */
   moduleScroll?: ContextRailScroll;
+  /**
+   * Desktop header "leading" content (section tabs) surfaced under the menu
+   * drawer on mobile. Anchors inside auto-close the drawer on click.
+   */
+  sectionTabs?: ReactNode;
   /** Panels drawer source. */
   panelViews?: PanelView[];
   /**
@@ -77,8 +87,11 @@ export function MobileDrawers({
   workspaceMenuFooter,
   module,
   moduleAppId,
+  moduleActiveItemId,
+  moduleRenderLink,
   moduleHeader,
   moduleScroll,
+  sectionTabs,
   panelViews = [],
   defaultView,
   customContent = {},
@@ -106,12 +119,15 @@ export function MobileDrawers({
         renderLink={menuRenderLink}
         workspaceItems={workspaceMenuItems}
         workspaceFooter={workspaceMenuFooter}
+        sectionTabs={sectionTabs}
       />
       <ModuleDrawer
         open={open === 'module-drawer'}
         onClose={close}
         module={module}
+        activeItemId={moduleActiveItemId}
         renderCtx={moduleRenderCtx}
+        renderLink={moduleRenderLink}
         header={moduleHeader}
         scroll={moduleScroll}
       />
@@ -151,6 +167,7 @@ function MenuDrawer({
   renderLink,
   workspaceItems,
   workspaceFooter,
+  sectionTabs,
 }: {
   open: boolean;
   onClose: () => void;
@@ -159,9 +176,20 @@ function MenuDrawer({
   renderLink?: IconRailProps['renderLink'];
   workspaceItems?: WorkspaceMenuItem[];
   workspaceFooter?: ReactNode;
+  sectionTabs?: ReactNode;
 }) {
   const hasIconItems = items.length > 0;
   const hasWorkspaceItems = Array.isArray(workspaceItems) && workspaceItems.length > 0;
+  const hasSectionTabs = sectionTabs != null;
+
+  // The desktop "leading" section tabs (e.g. Home / Inbox) live under the menu
+  // on mobile. The tabs are router Links; clicking one navigates client-side,
+  // so close the drawer when any anchor inside is activated.
+  const handleSectionTabsClick = (event: MouseEvent<HTMLDivElement>) => {
+    if ((event.target as HTMLElement).closest('a')) {
+      onClose();
+    }
+  };
 
   /* v8 ignore next — v8 phantom duplicate return statement for MenuDrawer */
   return (
@@ -174,6 +202,20 @@ function MenuDrawer({
           </DrawerDescription>
         </DrawerHeader>
         <div className="flex flex-col gap-2 p-2">
+          {hasSectionTabs && (
+            <>
+              {/* biome-ignore lint/a11y/useKeyWithClickEvents: delegated close; the section tabs are themselves interactive anchors */}
+              {/* biome-ignore lint/a11y/noStaticElementInteractions: container only delegates close to its interactive anchor children */}
+              <div
+                data-meda-mobile-section-tabs=""
+                className="flex h-9 items-stretch overflow-x-auto px-1"
+                onClick={handleSectionTabsClick}
+              >
+                {sectionTabs}
+              </div>
+              <div className="h-px bg-border" />
+            </>
+          )}
           {hasIconItems && (
             <nav aria-label="Primary navigation" className="flex flex-col gap-0.5">
               {items.map((item) => (
@@ -363,14 +405,18 @@ function ModuleDrawer({
   open,
   onClose,
   module,
+  activeItemId,
   renderCtx,
+  renderLink,
   header = 'auto',
   scroll = 'auto',
 }: {
   open: boolean;
   onClose: () => void;
   module?: ContextModule;
+  activeItemId?: string;
   renderCtx: ShellRenderContext;
+  renderLink?: ContextRailProps['renderLink'];
   header?: ContextRailHeader;
   scroll?: ContextRailScroll;
 }) {
@@ -406,16 +452,37 @@ function ModuleDrawer({
             <nav className="flex flex-col gap-0.5 p-2">
               {items.map((item) => {
                 const Icon = item.icon;
-                return (
-                  <a
-                    key={item.id}
-                    href={item.to}
-                    onClick={onClose}
-                    className="flex items-center gap-2 rounded-md px-3 py-2 text-sm text-muted-foreground hover:bg-accent hover:text-foreground"
-                  >
+                const isActive = item.id === activeItemId;
+                const className = cn(
+                  'flex items-center gap-2 rounded-md px-3 py-2 text-sm text-muted-foreground hover:bg-accent hover:text-foreground',
+                  isActive && 'bg-accent text-foreground'
+                );
+                const children = (
+                  <>
                     <Icon size={16} aria-hidden="true" />
                     <span>{item.label}</span>
-                  </a>
+                  </>
+                );
+                const linkProps = {
+                  href: item.to,
+                  'aria-current': isActive ? ('page' as const) : undefined,
+                  className,
+                  children,
+                };
+                if (renderLink) {
+                  return (
+                    <Fragment key={item.id}>
+                      {closeAfterLinkClick(
+                        renderLink({ item, isActive, className, children, linkProps }),
+                        onClose
+                      )}
+                    </Fragment>
+                  );
+                }
+                return (
+                  <Fragment key={item.id}>
+                    {closeAfterLinkClick(<a {...linkProps} />, onClose)}
+                  </Fragment>
                 );
               })}
             </nav>

--- a/src/shell/internal/mobile-header.tsx
+++ b/src/shell/internal/mobile-header.tsx
@@ -17,6 +17,8 @@ export interface MobileHeaderProps {
   onBack?: () => void;
   /** Root mode only — renders to the right of workspace name. */
   globalActions?: ReactNode;
+  /** Root mode only — rendered centered in the header (e.g. clock). */
+  headerCenter?: ReactNode;
   className?: string;
 }
 
@@ -34,6 +36,7 @@ export function MobileHeader({
   title,
   onBack,
   globalActions,
+  headerCenter,
   className,
 }: MobileHeaderProps) {
   const ctx = useMedaShell();
@@ -47,7 +50,7 @@ export function MobileHeader({
       data-testid="mobile-header"
       data-meda-mobile-header={isNested ? 'nested' : 'root'}
       className={cn(
-        'flex h-[var(--shell-header-height)] items-center justify-between border-b border-border bg-card px-3',
+        'relative flex h-[var(--shell-mobile-header-height)] items-center justify-between bg-background px-3',
         className
       )}
     >
@@ -56,26 +59,46 @@ export function MobileHeader({
           type="button"
           onClick={onBack}
           aria-label="Go back"
-          className="flex items-center gap-1.5 rounded-md px-2 py-1.5 text-sm hover:bg-accent"
+          className="flex min-h-9 max-w-full items-center gap-1.5 rounded-lg px-2 text-sm font-medium hover:bg-accent"
         >
-          <ChevronLeft size={16} aria-hidden="true" />
-          <span className="text-muted-foreground">{parentLabel}</span>
+          <ChevronLeft size={18} aria-hidden="true" />
+          <span className="truncate text-muted-foreground">{parentLabel}</span>
           {title && (
             <>
               <span className="text-muted-foreground/40" aria-hidden="true">
                 ·
               </span>
-              <span className="text-foreground">{title}</span>
+              <span className="truncate text-foreground">{title}</span>
             </>
           )}
         </button>
       ) : (
         <>
-          <div className="flex items-center gap-2 text-sm font-medium text-foreground">
-            <span aria-hidden="true">{ctx.workspace.icon}</span>
-            <span>{ctx.workspace.name}</span>
-          </div>
-          {globalActions && <div className="flex items-center gap-1">{globalActions}</div>}
+          {/* Workspace identity opens the menu drawer (same surface as the
+              bottom-nav Menu button) — no separate hamburger needed. */}
+          <button
+            type="button"
+            onClick={() => ctx.mobileDrawer.setOpen('menu-drawer')}
+            aria-label="Open workspace menu"
+            aria-haspopup="menu"
+            className="-mx-1 flex min-w-0 items-center gap-2.5 rounded-lg px-1 py-1 text-sm font-semibold text-foreground hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <span
+              className="inline-flex size-8 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-muted text-foreground ring-1 ring-border/70"
+              aria-hidden="true"
+            >
+              {ctx.workspace.icon}
+            </span>
+            <span className="truncate text-[15px] leading-5">{ctx.workspace.name}</span>
+          </button>
+          {headerCenter && (
+            <div className="-translate-x-1/2 pointer-events-none absolute left-1/2 flex max-w-[55%] items-center justify-center">
+              <div className="pointer-events-auto flex min-w-0 items-center">{headerCenter}</div>
+            </div>
+          )}
+          {globalActions && (
+            <div className="flex shrink-0 items-center gap-1.5">{globalActions}</div>
+          )}
         </>
       )}
     </header>

--- a/src/shell/shell-header.tsx
+++ b/src/shell/shell-header.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { LucideIcon } from 'lucide-react';
-import { ChevronDown, Monitor, Moon, PanelRightClose, PanelRightOpen, Sun } from 'lucide-react';
+import { ChevronDown, Monitor, Moon, PanelRight, Sun } from 'lucide-react';
 import { createElement, Fragment, isValidElement, type ReactNode } from 'react';
 import {
   DropdownMenu,
@@ -13,7 +13,7 @@ import {
 import { cn } from '../lib/utils.js';
 import { useMedaShell } from './shell-provider.js';
 import { useTheme } from './theme.js';
-import type { AppShellAppTabsConfig, WorkspaceMenuItem } from './types.js';
+import type { AppShellAppTabsConfig, PanelView, WorkspaceMenuItem } from './types.js';
 import { useShellViewport } from './use-shell-viewport.js';
 
 // ---------------------------------------------------------------------------
@@ -126,27 +126,37 @@ export function WorkspaceSwitcher({
         render={
           <button
             type="button"
-            className="flex items-center gap-1.5 rounded-md px-2 py-1.5 text-sm font-medium hover:bg-accent"
+            className="flex min-w-0 items-center gap-2.5 rounded-lg px-2.5 py-2 text-sm font-semibold hover:bg-accent"
           />
         }
       >
         {workspace.icon != null && (
-          <span className="shrink-0" aria-hidden="true">
+          <span
+            className="inline-flex size-8 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-muted text-foreground ring-1 ring-border/70"
+            aria-hidden="true"
+          >
             {workspace.icon}
           </span>
         )}
-        <span>{workspace.name}</span>
-        <ChevronDown size={14} aria-hidden="true" />
+        <span className="max-w-[13rem] truncate">{workspace.name}</span>
+        <ChevronDown size={16} aria-hidden="true" />
       </DropdownMenuTrigger>
 
-      <DropdownMenuContent className="min-w-[200px]">
+      <DropdownMenuContent className="min-w-[240px]">
         {/* Workspace list */}
-        {workspaces.length > 0 && (
+        {!useConfiguredItems && workspaces.length > 0 && (
           <>
             {workspaces.map((ws) => (
               <DropdownMenuItem key={ws.id}>
                 {/* TODO: wire setWorkspace once the provider exposes it. */}
-                {ws.icon != null && <span aria-hidden="true">{ws.icon}</span>}
+                {ws.icon != null && (
+                  <span
+                    className="inline-flex size-7 shrink-0 items-center justify-center overflow-hidden rounded-md bg-muted text-foreground ring-1 ring-border/70"
+                    aria-hidden="true"
+                  >
+                    {ws.icon}
+                  </span>
+                )}
                 {ws.name}
               </DropdownMenuItem>
             ))}
@@ -259,30 +269,93 @@ export function AppTabs({ renderLink }: AppTabsProps = {}) {
 // PanelToggle
 // ---------------------------------------------------------------------------
 
-export function PanelToggle() {
+export interface PanelToggleProps {
+  /** Panel views surfaced in the chevron dropdown. Empty → plain toggle. */
+  panelViews?: PanelView[];
+}
+
+export function PanelToggle({ panelViews = [] }: PanelToggleProps = {}) {
   const { panel } = useMedaShell();
   const isOpen = panel.mode !== 'closed';
 
-  const handleClick = () => {
-    panel.setMode(isOpen ? 'closed' : 'panel');
+  // No registered views → a single button that just opens/closes the panel.
+  if (panelViews.length === 0) {
+    return (
+      <button
+        type="button"
+        aria-label={isOpen ? 'Close right panel' : 'Open right panel'}
+        aria-pressed={isOpen}
+        onClick={() => panel.setMode(isOpen ? 'closed' : 'panel')}
+        className={cn(
+          'inline-flex h-9 items-center gap-1.5 rounded-[10px] bg-accent px-2.5 text-muted-foreground transition-colors hover:text-foreground',
+          isOpen && 'text-foreground'
+        )}
+      >
+        <PanelRight size={18} aria-hidden="true" />
+      </button>
+    );
+  }
+
+  // Clicking a view toggles it: selecting the already-open view closes the
+  // panel; selecting any other view opens the panel focused on that view.
+  const handleSelect = (viewId: string) => {
+    if (isOpen && panel.activeView === viewId) {
+      panel.close();
+    } else {
+      panel.focus(viewId);
+    }
   };
 
+  // ONE grouped control: the whole pill (panel icon + chevron) is a single
+  // dropdown trigger — not two separate buttons.
   return (
-    <button
-      type="button"
-      aria-label={isOpen ? 'Close right panel' : 'Open right panel'}
-      onClick={handleClick}
-      className={cn(
-        'inline-flex h-8 w-8 items-center justify-center rounded-md transition-colors',
-        isOpen ? 'bg-accent text-accent-foreground' : 'text-muted-foreground hover:bg-accent'
-      )}
-    >
-      {isOpen ? (
-        <PanelRightClose size={18} aria-hidden="true" />
-      ) : (
-        <PanelRightOpen size={18} aria-hidden="true" />
-      )}
-    </button>
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <button
+            type="button"
+            aria-label="Right panel views"
+            className={cn(
+              'inline-flex h-9 items-center gap-1.5 rounded-[10px] bg-accent px-2.5 text-muted-foreground transition-colors hover:text-foreground data-[popup-open]:text-foreground',
+              isOpen && 'text-foreground'
+            )}
+          />
+        }
+      >
+        <PanelRight size={18} aria-hidden="true" />
+        <ChevronDown size={14} aria-hidden="true" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" sideOffset={8} className="w-64 rounded-xl p-1.5">
+        <div className="px-2 pt-1.5 pb-1 font-bold text-[10.5px] uppercase tracking-wider text-muted-foreground">
+          Panel views
+        </div>
+        {panelViews.map((view) => {
+          const Icon = view.icon;
+          const active = isOpen && panel.activeView === view.id;
+          return (
+            <DropdownMenuItem
+              key={view.id}
+              onClick={() => handleSelect(view.id)}
+              className={cn(
+                'gap-2.5 rounded-[9px] px-2.5 py-2 text-sm',
+                active && 'text-foreground'
+              )}
+            >
+              <span
+                className={cn(
+                  'grid h-[26px] w-[26px] shrink-0 place-items-center rounded-[7px] transition-colors',
+                  active ? 'bg-primary/15 text-primary' : 'bg-muted text-muted-foreground'
+                )}
+              >
+                {Icon != null ? <Icon size={16} aria-hidden="true" /> : null}
+              </span>
+              <span className="flex-1 font-medium">{view.label}</span>
+              {active ? <span className="size-1.5 rounded-full bg-primary" /> : null}
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 
@@ -297,6 +370,11 @@ export interface ShellHeaderProps {
    * provided.
    */
   headerCenter?: ReactNode;
+  /**
+   * Optional leading content rendered in the LEFT header region immediately
+   * after the workspace switcher (separated by whitespace only, no divider).
+   */
+  headerLeading?: ReactNode;
   appTabsRenderLink?: AppShellAppTabsConfig['renderLink'];
   className?: string;
   /**
@@ -305,42 +383,81 @@ export interface ShellHeaderProps {
    */
   workspaceMenuItems?: WorkspaceMenuItem[];
   workspaceMenuFooter?: ReactNode;
+  showPanelToggle?: boolean;
+  /** Panel views forwarded to the header `<PanelToggle>` dropdown. */
+  panelViews?: PanelView[];
 }
 
 /* v8 ignore next — v8 phantom duplicate function record for ShellHeader (default params) */
 export function ShellHeader({
   globalActions,
   headerCenter,
+  headerLeading,
   appTabsRenderLink,
   className,
   workspaceMenuItems,
   workspaceMenuFooter,
+  showPanelToggle = true,
+  panelViews = [],
 }: ShellHeaderProps = {}) {
   const band = useShellViewport();
   if (band === 'mobile') return null;
+
+  // Leading content (e.g. section tabs) sits in the LEFT region just after
+  // the WorkspaceSwitcher — separated by whitespace only (no divider line),
+  // matching the design prototype's topbar spacing.
+  const leadingRegion =
+    headerLeading != null ? (
+      <div className="ml-2 flex min-w-0 items-center">{headerLeading}</div>
+    ) : null;
+
+  if (headerCenter !== undefined) {
+    return (
+      <header
+        className={cn(
+          'grid h-[var(--shell-header-height)] w-full grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center',
+          'gap-4 bg-background px-4',
+          className
+        )}
+      >
+        <div className="flex min-w-0 items-center gap-2 justify-self-start">
+          <WorkspaceSwitcher menuItems={workspaceMenuItems} menuFooter={workspaceMenuFooter} />
+          {leadingRegion}
+        </div>
+        <div className="flex min-w-0 items-center justify-center justify-self-center">
+          {headerCenter}
+        </div>
+        <div className="flex min-w-0 items-center justify-end gap-2 justify-self-end">
+          {globalActions}
+          {showPanelToggle && <PanelToggle panelViews={panelViews} />}
+        </div>
+      </header>
+    );
+  }
 
   return (
     <header
       className={cn(
         'flex h-[var(--shell-header-height)] w-full items-center justify-between',
-        'gap-3 border-b border-border bg-background px-3',
+        'gap-4 bg-background px-4',
         className
       )}
     >
-      {/* Left region: workspace identity and switcher. */}
-      <div className="flex shrink-0 items-center">
+      {/* Left region: workspace identity and switcher + optional leading slot. */}
+      <div className="flex min-w-0 shrink-0 items-center gap-2">
         <WorkspaceSwitcher menuItems={workspaceMenuItems} menuFooter={workspaceMenuFooter} />
+        {leadingRegion}
       </div>
 
-      {/* Center region: consumer chrome or the default application tabs. */}
+      {/* Center region: the default application tabs. */}
       <div className="flex min-w-0 flex-1 items-center">
-        {headerCenter !== undefined ? headerCenter : <AppTabs renderLink={appTabsRenderLink} />}
+        <AppTabs renderLink={appTabsRenderLink} />
       </div>
 
-      {/* Right region: optional globalActions slot then mandatory PanelToggle */}
+      {/* Right region: optional globalActions slot then PanelToggle */}
       <div className="flex shrink-0 items-center gap-2">
         {globalActions}
-        <PanelToggle />
+        {showPanelToggle && <PanelToggle panelViews={panelViews} />}
       </div>
     </header>
   );

--- a/src/shell/shell-main.tsx
+++ b/src/shell/shell-main.tsx
@@ -19,12 +19,7 @@ export function ShellMain({ layout = 'workspace', className, children }: ShellMa
   return (
     <main
       data-meda-shell-main-layout={layout}
-      className={cn(
-        'flex-1 min-w-0 overflow-y-auto bg-shell-main',
-        '[content-visibility:auto]',
-        layoutClass[layout],
-        className
-      )}
+      className={cn('flex-1 min-w-0 overflow-y-auto bg-shell-main', layoutClass[layout], className)}
     >
       {children}
     </main>

--- a/src/shell/types.ts
+++ b/src/shell/types.ts
@@ -120,6 +120,7 @@ export interface AppShellIconRailConfig {
   footer?: ReactNode;
   activeId?: string;
   renderLink?: import('./icon-rail.js').IconRailProps['renderLink'];
+  labelVisibility?: import('./icon-rail.js').IconRailProps['labelVisibility'];
 }
 
 /** ContextRail configuration for `<AppShell variant="workspace">`. */
@@ -127,6 +128,7 @@ export interface AppShellContextRailConfig {
   appId: string;
   module: ContextModule;
   activeItemId?: string;
+  renderLink?: import('./context-rail.js').ContextRailProps['renderLink'];
   header?: ContextRailHeader;
   scroll?: ContextRailScroll;
 }

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,4 +1,5 @@
 @import "./tokens.css";
+@import "@xyflow/react/dist/style.css";
 
 /* Tell Tailwind v4 to scan meda's compiled component output so utilities
    like `h-full`, `mt-auto`, `py-3.5`, and `bg-shell-rail` (used by IconRail,

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -236,8 +236,10 @@
   --shell-panel: var(--color-neutral-50);
   --shell-border: var(--color-neutral-200);
   --shell-shadow: 0 4px 12px hsl(0 0% 0% / 0.04);
-  --shell-header-height: 56px;
+  --shell-header-height: 64px;
+  --shell-mobile-header-height: 48px;
   --shell-rail-width: 60px;
+  --shell-rail-label-width: 88px;
   --shell-context-default: 300px;
   --shell-context-min: 240px;
   --shell-context-max: 420px;

--- a/src/workflow-builder/workflow-canvas.tsx
+++ b/src/workflow-builder/workflow-canvas.tsx
@@ -12,7 +12,6 @@ import {
   ReactFlow,
   type ReactFlowProps,
 } from '@xyflow/react';
-import '@xyflow/react/dist/style.css';
 
 import { useCallback } from 'react';
 import { cn } from '../lib/utils.js';

--- a/test/unit/shell/app-shell-workspace.test.tsx
+++ b/test/unit/shell/app-shell-workspace.test.tsx
@@ -198,9 +198,12 @@ describe('AppShellWorkspace', () => {
     expect(main).toHaveClass('custom-main');
   });
 
-  it('auto-mounts the command palette registry for workspace descendants', () => {
+  it('auto-mounts the built-in command palette by default so useCommands() works', () => {
     (useShellViewport as ReturnType<typeof vi.fn>).mockReturnValue('desktop');
 
+    // Backwards-compatible default: meda wraps the shell in its own
+    // <CommandPalette>, providing the CommandRegistryContext, so descendants
+    // that call useCommands() work without the host supplying a palette.
     render(
       <Provider>
         <AppShellWorkspace>
@@ -210,6 +213,33 @@ describe('AppShellWorkspace', () => {
     );
 
     expect(screen.getByTestId('command-registration-probe')).toBeInTheDocument();
+  });
+
+  it('opts out of the built-in palette with builtInCommandPalette={false}', () => {
+    (useShellViewport as ReturnType<typeof vi.fn>).mockReturnValue('desktop');
+
+    // Apps that ship their own palette opt out to avoid a duplicate dialog.
+    // With no host palette and the built-in disabled, useCommands() throws.
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() =>
+      render(
+        <Provider>
+          <AppShellWorkspace builtInCommandPalette={false}>
+            <CommandRegistrationProbe />
+          </AppShellWorkspace>
+        </Provider>
+      )
+    ).toThrow(/useCommands must be used inside <CommandPalette>/);
+    consoleError.mockRestore();
+
+    render(
+      <Provider>
+        <AppShellWorkspace builtInCommandPalette={false}>
+          <main aria-label="content">hi</main>
+        </AppShellWorkspace>
+      </Provider>
+    );
+    expect(screen.getByRole('main', { name: 'content' })).toBeInTheDocument();
   });
 
   it('does not mount a second command palette when a consumer already provides one', () => {

--- a/test/unit/shell/app-shell.test.tsx
+++ b/test/unit/shell/app-shell.test.tsx
@@ -151,6 +151,6 @@ describe('AppShellBody', () => {
     expect(root.className).toContain('relative');
     expect(root.className).toContain('flex');
     expect(root.className).toContain('overflow-hidden');
-    expect(root.className).toContain('h-[calc(100vh-var(--shell-header-height))]');
+    expect(root.className).toContain('h-[calc(100svh-var(--shell-header-height))]');
   });
 });

--- a/test/unit/shell/context-rail.test.tsx
+++ b/test/unit/shell/context-rail.test.tsx
@@ -157,38 +157,45 @@ describe('ContextRail — layout + visibility', () => {
     expect(screen.queryByRole('complementary')).not.toBeInTheDocument();
   });
 
-  it('resize handle is present with opacity-0 and hover:opacity-100 classes', () => {
+  it('seam wrapper hosts the resize separator and the unified group/seam reveal scope', () => {
     render(
       <Wrapper>
         <ContextRail appId="mail" module={MODULE} />
       </Wrapper>
     );
 
-    const handle = screen.getByRole('separator', { name: 'Resize context rail' });
-    expect(handle.className).toContain('opacity-0');
-    expect(handle.className).toContain('hover:opacity-100');
+    // The resize separator semantics live on the thin seam line; the wrapper
+    // (data-testid="context-rail-seam") owns positioning + the group/seam scope
+    // so the line + grip reveal together on rail hover. The grip button is a
+    // sibling of the separator (not nested) — keeps roles a11y-valid.
+    const separator = screen.getByRole('separator', { name: 'Resize context rail' });
+    const seam = screen.getByTestId('context-rail-seam');
+    expect(seam).toContainElement(separator);
+    expect(seam).toContainElement(screen.getByTestId('context-rail-toggle'));
+    expect(seam.className).toContain('group/seam');
   });
 
-  it('resize handle is 4px wide (w-1 class)', () => {
+  it('seam straddles the rail boundary (w-3 + translate-x-1/2)', () => {
     render(
       <Wrapper>
         <ContextRail appId="mail" module={MODULE} />
       </Wrapper>
     );
 
-    const handle = screen.getByRole('separator', { name: 'Resize context rail' });
-    expect(handle.className).toContain('w-1');
+    const seam = screen.getByTestId('context-rail-seam');
+    expect(seam.className).toContain('w-3');
+    expect(seam.className).toContain('translate-x-1/2');
   });
 
-  it('resize handle has cursor-col-resize class', () => {
+  it('seam has cursor-col-resize class when expanded', () => {
     render(
       <Wrapper>
         <ContextRail appId="mail" module={MODULE} />
       </Wrapper>
     );
 
-    const handle = screen.getByRole('separator', { name: 'Resize context rail' });
-    expect(handle.className).toContain('cursor-col-resize');
+    const seam = screen.getByTestId('context-rail-seam');
+    expect(seam.className).toContain('cursor-col-resize');
   });
 });
 
@@ -611,21 +618,27 @@ describe('collapse toggle', () => {
     expect(btn).toHaveAttribute('aria-expanded', 'true');
   });
 
-  it('does not render the resize handle when collapsed', () => {
+  it('keeps the seam mounted when collapsed (so the rail can be reopened) but disables resize', () => {
     render(
       <Wrapper>
         <ContextRail appId="mail" module={MODULE} />
       </Wrapper>
     );
-    expect(screen.queryByRole('separator', { name: /resize context rail/i })).toBeInTheDocument();
+    const seam = screen.getByTestId('context-rail-seam');
+    expect(seam).toBeInTheDocument();
+    expect(seam.getAttribute('data-collapsed')).toBe('false');
+    expect(seam.className).toContain('cursor-col-resize');
+    expect(screen.getByRole('separator', { name: /resize context rail/i })).toBeInTheDocument();
 
-    // Collapse via the toggle
+    // Collapse via the grip — the unified seam stays mounted (it carries the
+    // expand grip) but flips to a non-resizable state.
     act(() => {
       fireEvent.click(screen.getByTestId('context-rail-toggle'));
     });
-    expect(
-      screen.queryByRole('separator', { name: /resize context rail/i })
-    ).not.toBeInTheDocument();
+    const collapsedSeam = screen.getByTestId('context-rail-seam');
+    expect(collapsedSeam).toBeInTheDocument();
+    expect(collapsedSeam.getAttribute('data-collapsed')).toBe('true');
+    expect(collapsedSeam.className).toContain('cursor-default');
   });
 
   it('does not render the toggle on mobile viewport', () => {

--- a/test/unit/shell/icon-rail.test.tsx
+++ b/test/unit/shell/icon-rail.test.tsx
@@ -113,7 +113,7 @@ describe('IconRail', () => {
     expect(screen.getByRole('tooltip')).toHaveTextContent('Inbox');
   });
 
-  it('active item has bg-primary/12 and text-primary classes', () => {
+  it('active item has solid bg-primary, primary-foreground text and ring', () => {
     render(
       <Wrapper>
         <IconRail
@@ -124,11 +124,12 @@ describe('IconRail', () => {
     );
 
     const trigger = screen.getByTestId('icon-rail-trigger-inbox');
-    expect(trigger.className).toContain('bg-primary/12');
-    expect(trigger.className).toContain('text-primary');
+    expect(trigger.className).toContain('bg-primary');
+    expect(trigger.className).toContain('text-primary-foreground');
+    expect(trigger.className).toContain('ring-2');
   });
 
-  it('inactive item does NOT have bg-primary/12', () => {
+  it('inactive item does NOT have bg-primary', () => {
     render(
       <Wrapper>
         <IconRail mainItems={mainItems} activeId="inbox" />
@@ -136,7 +137,7 @@ describe('IconRail', () => {
     );
 
     const settingsTrigger = screen.getByTestId('icon-rail-trigger-settings');
-    expect(settingsTrigger.className).not.toContain('bg-primary/12');
+    expect(settingsTrigger.className).not.toContain('bg-primary');
   });
 
   it('renderLink prop wraps each item', () => {

--- a/test/unit/shell/shell-main.test.tsx
+++ b/test/unit/shell/shell-main.test.tsx
@@ -83,27 +83,27 @@ describe('ShellMain — layout="fullbleed"', () => {
 });
 
 describe('ShellMain — content-visibility', () => {
-  it('applies [content-visibility:auto] class on every layout', () => {
+  it('does NOT apply [content-visibility:auto] (removed — it broke sticky/measured children)', () => {
     const { rerender } = render(
       <ShellMain>
         <div />
       </ShellMain>
     );
-    expect(screen.getByRole('main').className).toContain('[content-visibility:auto]');
+    expect(screen.getByRole('main').className).not.toContain('[content-visibility:auto]');
 
     rerender(
       <ShellMain layout="centered">
         <div />
       </ShellMain>
     );
-    expect(screen.getByRole('main').className).toContain('[content-visibility:auto]');
+    expect(screen.getByRole('main').className).not.toContain('[content-visibility:auto]');
 
     rerender(
       <ShellMain layout="fullbleed">
         <div />
       </ShellMain>
     );
-    expect(screen.getByRole('main').className).toContain('[content-visibility:auto]');
+    expect(screen.getByRole('main').className).not.toContain('[content-visibility:auto]');
   });
 });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -103,7 +103,13 @@ export default defineConfig({
           setupFiles: ['./vitest.setup.ts'],
           // Integration tests (test/nextjs-consumer.test.ts) require pnpm build first; run via pnpm test:integration.
           // demo/ requires a built dist/ — excluded from unit runs, covered by test:integration.
-          exclude: ['**/node_modules/**', '**/dist/**', 'test/nextjs-consumer.test.ts', 'demo/**'],
+          exclude: [
+            '**/node_modules/**',
+            '**/dist/**',
+            '**/.worktrees/**',
+            'test/nextjs-consumer.test.ts',
+            'demo/**',
+          ],
         },
       },
       {


### PR DESCRIPTION
Promotes `dev` → `prod` to release. Pending changeset: `shell-mobile-and-panel-views` (minor → **2.5.0**). The only feature is #172 (shell port of the medal-monorepo pnpm patch). Merging triggers the Changesets Release PR which publishes 2.5.0 via OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)