### PR TITLE
fix(shell): make ShellMain a flex column

### DIFF
--- a/.changeset/shell-main-flex-column.md
+++ b/.changeset/shell-main-flex-column.md
@@ -1,0 +1,13 @@
+---
+"@medalsocial/meda": patch
+---
+
+fix(shell): make `ShellMain` a flex column (`flex flex-col`).
+
+Full-height content regions that use `flex-1` to fill the main area need a
+flex-column parent with a definite height. Without it those regions collapse to
+their min content height and, when combined with `overflow-hidden`, clip their
+content — pages such as the posts list/calendar rendered into the DOM but stayed
+visually blank. Adding `flex flex-col` to `<main>` restores the height contract
+those pages rely on (purely additive; padded/scrolling `workspace` layouts are
+unaffected).

--- a/src/shell/shell-main.tsx
+++ b/src/shell/shell-main.tsx
@@ -19,7 +19,15 @@ export function ShellMain({ layout = 'workspace', className, children }: ShellMa
   return (
     <main
       data-meda-shell-main-layout={layout}
-      className={cn('flex-1 min-w-0 overflow-y-auto bg-shell-main', layoutClass[layout], className)}
+      className={cn(
+        // `flex flex-col` is required so full-height content regions (pages that
+        // use `flex-1` to fill the main area) get a flex-column parent with a
+        // definite height. Without it, those regions collapse and clip their
+        // content (e.g. the Posts list rendered but stayed blank).
+        'flex flex-col flex-1 min-w-0 overflow-y-auto bg-shell-main',
+        layoutClass[layout],
+        className
+      )}
     >
       {children}
     </main>


### PR DESCRIPTION
## Problem

`ShellMain` renders `<main>` without `flex flex-col`. Pages whose top-level region uses `flex-1` to fill the main area (e.g. the consumer's Posts list/board/calendar) get a parent with no definite height, collapse to their min content height, and — combined with `overflow-hidden` — clip their content. The content renders into the DOM but stays visually blank.

## Fix

Add `flex flex-col` to the `<main>` class list. Purely additive — padded/scrolling `workspace` layouts are unaffected; it restores the height contract full-height pages rely on.

Verified against the consumer app on staging: injecting `flex flex-col` onto `<main>` restores the Posts list (wrapper height 57px → full height).

Changeset: `patch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)