### PR TITLE
fix(shell): icon rail scales and scrolls on short viewports

### DIFF
--- a/.changeset/icon-rail-short-viewport-scaling.md
+++ b/.changeset/icon-rail-short-viewport-scaling.md
@@ -1,0 +1,5 @@
+---
+'@medalsocial/meda': patch
+---
+
+IconRail now adapts to short viewports: items compact below 850px viewport height (smaller icon frame, tighter spacing, smaller label) and labels hide below 700px so the rail degrades to icon-only. The rail also scrolls vertically (hidden scrollbar) as a hard guarantee that every menu item stays reachable on small screens — previously items below the fold were unreachable on ~12" displays.

--- a/src/shell/icon-rail.tsx
+++ b/src/shell/icon-rail.tsx
@@ -49,15 +49,22 @@ export interface IconRailProps {
 // Item styling
 // ---------------------------------------------------------------------------
 
+// Short-viewport scaling: below 850px viewport height items compact (smaller
+// icon frame, tighter spacing, smaller label); below 700px labels hide so the
+// rail degrades to icon-only. The rail additionally scrolls (see railClass) as
+// the hard guarantee that every item stays reachable on any height.
 function itemClass(isActive: boolean, labelVisibility: IconRailLabelVisibility) {
   if (labelVisibility === 'visible') {
     return cn(
-      'group relative flex min-h-[4rem] w-full flex-col items-center justify-start gap-1 px-1 py-1 text-center transition-colors',
+      'group relative flex min-h-[4rem] w-full shrink-0 flex-col items-center justify-start gap-1 px-1 py-1 text-center transition-colors',
+      '[@media(max-height:850px)]:min-h-[3.25rem] [@media(max-height:850px)]:gap-0.5',
+      '[@media(max-height:700px)]:min-h-0',
       isActive ? 'text-foreground' : 'text-muted-foreground hover:text-foreground'
     );
   }
   return cn(
-    'group relative flex h-11 w-11 items-center justify-center rounded-xl transition-colors',
+    'group relative flex h-11 w-11 shrink-0 items-center justify-center rounded-xl transition-colors',
+    '[@media(max-height:700px)]:h-9 [@media(max-height:700px)]:w-9',
     isActive
       ? 'bg-primary text-primary-foreground shadow-sm ring-2 ring-primary/60'
       : 'text-muted-foreground hover:bg-accent hover:text-foreground'
@@ -67,6 +74,7 @@ function itemClass(isActive: boolean, labelVisibility: IconRailLabelVisibility) 
 function iconFrameClass(isActive: boolean) {
   return cn(
     'relative inline-flex h-11 w-11 items-center justify-center rounded-xl transition-colors',
+    '[@media(max-height:850px)]:h-9 [@media(max-height:850px)]:w-9',
     isActive
       ? 'bg-primary text-primary-foreground shadow-sm ring-2 ring-primary/60'
       : 'group-hover:bg-accent group-hover:text-foreground'
@@ -76,9 +84,13 @@ function iconFrameClass(isActive: boolean) {
 function railClass(labelVisibility: IconRailLabelVisibility, className?: string) {
   return cn(
     'flex h-full shrink-0 flex-col items-center bg-shell-rail',
+    // Hard reachability guarantee on short viewports: the rail scrolls when the
+    // compact tiers still can't fit every item. Scrollbar is hidden — wheel,
+    // trackpad, and keyboard focus traversal still scroll the overflow.
+    'min-h-0 overflow-y-auto overflow-x-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
     labelVisibility === 'visible'
-      ? 'w-[var(--shell-rail-label-width)] px-2 py-4'
-      : 'w-[var(--shell-rail-width)] py-3.5',
+      ? 'w-[var(--shell-rail-label-width)] px-2 py-4 [@media(max-height:850px)]:py-2'
+      : 'w-[var(--shell-rail-width)] py-3.5 [@media(max-height:850px)]:py-2',
     className
   );
 }
@@ -102,7 +114,8 @@ export function RailDivider({ pinnedBottom, onToggle }: RailDividerProps) {
       onClick={onToggle}
       aria-label={pinnedBottom ? 'Pull utility items up' : 'Push utility items down'}
       className={cn(
-        'my-3 flex h-6 w-8 items-center justify-center rounded-md',
+        'my-3 flex h-6 w-8 shrink-0 items-center justify-center rounded-md',
+        '[@media(max-height:850px)]:my-1',
         'text-muted-foreground hover:bg-accent hover:text-foreground transition-colors'
       )}
     >
@@ -142,16 +155,19 @@ export function IconRail({
     const inner = showLabels ? (
       <>
         <span data-slot="icon-rail-icon-frame" className={iconFrameClass(isActive)}>
-          <IconComp size={26} aria-hidden="true" />
+          <IconComp size={26} aria-hidden="true" className="[@media(max-height:850px)]:size-5" />
           {item.badge ? <span className="absolute right-1 top-1">{item.badge}</span> : null}
         </span>
-        <span data-slot="icon-rail-label" className="max-w-full truncate text-[12px] leading-4">
+        <span
+          data-slot="icon-rail-label"
+          className="max-w-full truncate text-[12px] leading-4 [@media(max-height:850px)]:text-[11px] [@media(max-height:700px)]:hidden"
+        >
           {item.label}
         </span>
       </>
     ) : (
       <>
-        <IconComp size={22} aria-hidden="true" />
+        <IconComp size={22} aria-hidden="true" className="[@media(max-height:700px)]:size-[18px]" />
         {item.badge ? <span className="absolute right-1 top-1">{item.badge}</span> : null}
       </>
     );
@@ -197,7 +213,12 @@ export function IconRail({
         aria-label="Primary"
         className={railClass(labelVisibility, className)}
       >
-        <div className={cn('flex flex-col items-center', showLabels ? 'w-full gap-1' : 'gap-1')}>
+        <div
+          className={cn(
+            'flex shrink-0 flex-col items-center',
+            showLabels ? 'w-full gap-1' : 'gap-1'
+          )}
+        >
           {mainItems.map(renderItem)}
         </div>
         {utilityItems.length > 0 && (
@@ -209,7 +230,7 @@ export function IconRail({
             <div
               data-testid="utility-items-wrapper"
               className={cn(
-                'flex flex-col items-center',
+                'flex shrink-0 flex-col items-center',
                 showLabels ? 'w-full gap-1' : 'gap-1',
                 pinnedBottom && 'mt-auto'
               )}
@@ -219,7 +240,12 @@ export function IconRail({
           </>
         )}
         {footer && (
-          <div className={cn('pt-3', pinnedBottom || utilityItems.length === 0 ? 'mt-auto' : '')}>
+          <div
+            className={cn(
+              'shrink-0 pt-3 [@media(max-height:850px)]:pt-1.5',
+              pinnedBottom || utilityItems.length === 0 ? 'mt-auto' : ''
+            )}
+          >
             {footer}
           </div>
         )}

--- a/src/shell/icon-rail.tsx
+++ b/src/shell/icon-rail.tsx
@@ -3,7 +3,7 @@
 import type { LucideIcon } from 'lucide-react';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import type { AnchorHTMLAttributes, ReactNode } from 'react';
-import { Fragment, useState } from 'react';
+import { Fragment, useEffect, useState } from 'react';
 import {
   Tooltip,
   TooltipContent,
@@ -128,6 +128,24 @@ export function RailDivider({ pinnedBottom, onToggle }: RailDividerProps) {
   );
 }
 
+// Mirrors the [@media(max-height:700px)] CSS tier that hides visible-mode
+// labels, so those items regain a tooltip fallback exactly when their label
+// disappears. SSR-safe: initial false, resolves post-mount.
+function useIsShortViewport(): boolean {
+  const [isShort, setIsShort] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+    const mql = window.matchMedia('(max-height: 700px)');
+    const onChange = () => setIsShort(mql.matches);
+    onChange();
+    mql.addEventListener('change', onChange);
+    return () => mql.removeEventListener('change', onChange);
+  }, []);
+
+  return isShort;
+}
+
 // ---------------------------------------------------------------------------
 // IconRail
 // ---------------------------------------------------------------------------
@@ -142,11 +160,15 @@ export function IconRail({
   className,
 }: IconRailProps) {
   const band = useShellViewport();
+  const isShortViewport = useIsShortViewport();
   const [pinnedBottom, setPinnedBottom] = useState(true);
 
   if (band === 'mobile') return null;
 
   const showLabels = labelVisibility === 'visible';
+  // At ≤700px the visible-mode label is hidden by CSS, so items fall back to
+  // tooltip labels like tooltip mode does.
+  const useTooltipFallback = !showLabels || isShortViewport;
 
   const renderItem = (item: IconRailItem) => {
     const isActive = item.id === activeId;
@@ -193,7 +215,7 @@ export function IconRail({
       </span>
     );
 
-    if (showLabels) {
+    if (!useTooltipFallback) {
       return <Fragment key={item.id}>{trigger}</Fragment>;
     }
 

--- a/test/unit/shell/icon-rail.test.tsx
+++ b/test/unit/shell/icon-rail.test.tsx
@@ -82,6 +82,33 @@ describe('IconRail', () => {
     expect(nav.className).toContain('w-[var(--shell-rail-width)]');
   });
 
+  it('rail scrolls vertically so items stay reachable on short viewports (class contract)', () => {
+    render(
+      <Wrapper>
+        <IconRail mainItems={mainItems} />
+      </Wrapper>
+    );
+
+    const nav = screen.getByRole('navigation', { name: 'Primary' });
+    expect(nav.className).toContain('overflow-y-auto');
+    expect(nav.className).toContain('min-h-0');
+  });
+
+  it('compacts items below 850px and hides labels below 700px viewport height (class contract)', () => {
+    render(
+      <Wrapper>
+        <IconRail mainItems={mainItems} labelVisibility="visible" activeId="inbox" />
+      </Wrapper>
+    );
+
+    const trigger = screen.getByTestId('icon-rail-trigger-inbox');
+    expect(trigger.className).toContain('[@media(max-height:850px)]:min-h-[3.25rem]');
+    const label = trigger.querySelector('[data-slot="icon-rail-label"]');
+    expect(label?.className).toContain('[@media(max-height:700px)]:hidden');
+    const frame = trigger.querySelector('[data-slot="icon-rail-icon-frame"]');
+    expect(frame?.className).toContain('[@media(max-height:850px)]:h-9');
+  });
+
   it('does not expand on hover — width class unchanged after mouseEnter', () => {
     render(
       <Wrapper>

--- a/test/unit/shell/icon-rail.test.tsx
+++ b/test/unit/shell/icon-rail.test.tsx
@@ -94,6 +94,39 @@ describe('IconRail', () => {
     expect(nav.className).toContain('min-h-0');
   });
 
+  it('visible mode falls back to tooltips on short viewports where labels are hidden', async () => {
+    // matchMedia stub: report a short viewport for the label-hiding tier.
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    (window.matchMedia as any) = vi.fn().mockImplementation((query: string) => ({
+      matches: query === '(max-height: 700px)',
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+
+    render(
+      <Wrapper>
+        <IconRail
+          mainItems={[{ id: 'inbox', label: 'Inbox', to: '/inbox', icon: Inbox }]}
+          labelVisibility="visible"
+        />
+      </Wrapper>
+    );
+
+    const trigger = screen.getByTestId('icon-rail-trigger-inbox');
+    fireEvent.mouseEnter(trigger);
+    fireEvent.mouseMove(trigger);
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 800));
+    });
+    // Label span still rendered (CSS hides it), and tooltip provides the fallback
+    expect(trigger.querySelector('[data-slot="icon-rail-label"]')).toBeInTheDocument();
+    const tooltips = await screen.findAllByText('Inbox');
+    expect(tooltips.length).toBeGreaterThan(1);
+  });
+
   it('compacts items below 850px and hides labels below 700px viewport height (class contract)', () => {
     render(
       <Wrapper>


### PR DESCRIPTION
## Problem

The IconRail is a fixed-size flex column with no overflow handling and no height-aware scaling. On short viewports (~12" laptops, ≈650-700px available height) with `labelVisibility="visible"` (64px items, as used by medal-monorepo apps/web), bottom menu items render below the fold and are completely unreachable.

## Fix

Two height-adaptive compact tiers + a hard reachability guarantee:

- **≤850px viewport height**: items compact — icon frame 44→36px, icon 26→20px, label 12→11px, `min-h` 64→52px, tighter rail padding/divider/footer spacing
- **≤700px**: labels hide (icon-only), tooltip-mode items shrink 44→36px
- **Always**: the rail is `overflow-y-auto` (hidden scrollbar) with `shrink-0` children, so even extreme heights can scroll to every item instead of clipping them

All literal Tailwind arbitrary `max-height` variants — no new tokens, no custom variants, so consumers scanning `dist` via `@source` pick them up unchanged.

## Testing

- Full suite green: 219 files / 1563 tests
- New class-contract tests for the scroll guarantee and both compact tiers

🤖 Generated with [Claude Code](https://claude.com/claude-code)