### PR TITLE
feat(shell): full-width bar variant for the mobile dock

### DIFF
--- a/.changeset/mobile-dock-bar-variant.md
+++ b/.changeset/mobile-dock-bar-variant.md
@@ -1,0 +1,11 @@
+---
+'@medalsocial/meda': minor
+---
+
+feat(shell): full-width `bar` variant for the mobile dock
+
+`AppShellMobileNavConfig.variant` now accepts `'bar'` alongside the default
+`'pill'`. The `bar` renders a flat, full-width bottom bar of evenly-spread slots
+— each a larger icon + label with a tinted active state — mirroring the native
+mobile app; the brand item (e.g. Pilot) sits inline as the last slot. Fully
+additive: consumers that omit `variant` keep the floating pill.

--- a/src/shell/app-shell-workspace.tsx
+++ b/src/shell/app-shell-workspace.tsx
@@ -166,6 +166,7 @@ export function AppShellWorkspace({
             items={mobileNav.dock}
             activeTo={mobileNav.activeTo}
             renderLink={mobileNav.renderLink}
+            variant={mobileNav.variant}
           />
           <MobileWorkspaceSheet
             tree={mobileNav.tree}

--- a/src/shell/internal/mobile-dock.tsx
+++ b/src/shell/internal/mobile-dock.tsx
@@ -14,6 +14,8 @@ export interface MobileDockProps {
   activeTo?: string;
   renderLink?: (args: MobileNavLinkArgs) => ReactNode;
   className?: string;
+  /** `pill` (default) floating dock, or `bar` full-width labeled bottom bar. */
+  variant?: 'pill' | 'bar';
 }
 
 function renderIcon(icon: MobileDockItem['icon'], size: number): ReactNode {
@@ -27,12 +29,23 @@ function renderIcon(icon: MobileDockItem['icon'], size: number): ReactNode {
 }
 
 /**
- * Floating mobile dock — a pill of pinned destinations plus a workspace-sheet
- * trigger, with any `emphasis: 'brand'` item rendered as a standalone circle
- * (e.g. Pilot) beside the pill. Replaces the bordered bottom bar. Hidden on
- * non-mobile viewports and when the right panel is fullscreen.
+ * Mobile dock — pinned destinations plus a workspace-sheet trigger. Two shapes:
+ *
+ * - `pill` (default): a floating, centered pill of icon-only slots, with any
+ *   `emphasis: 'brand'` item (e.g. Pilot) as a standalone circle beside it.
+ * - `bar`: a flat, full-width bottom bar of evenly-spread slots — each a larger
+ *   icon + label with a tinted active state — mirroring the native app. The
+ *   brand item sits inline as the last slot (a filled circle).
+ *
+ * Hidden on non-mobile viewports and when the right panel is fullscreen.
  */
-export function MobileDock({ items, activeTo, renderLink, className }: MobileDockProps) {
+export function MobileDock({
+  items,
+  activeTo,
+  renderLink,
+  className,
+  variant = 'pill',
+}: MobileDockProps) {
   const ctx = useMedaShell();
   const band = useShellViewport();
 
@@ -40,14 +53,104 @@ export function MobileDock({ items, activeTo, renderLink, className }: MobileDoc
   if (ctx.panel.mode === 'fullscreen') return null;
   if (items.length === 0) return null;
 
-  const pillItems = items.filter((item) => item.emphasis !== 'brand');
-  const brandItems = items.filter((item) => item.emphasis === 'brand');
-
   const runAction = (item: MobileDockItem) => {
     if (item.action === 'open-sheet') ctx.mobileDrawer.setOpen(WORKSPACE_SHEET_KEY);
     else if (item.action === 'open-ai') ctx.mobileDrawer.setOpen('ai-drawer');
     else if (item.action === 'open-command-palette') ctx.commandPalette.setOpen(true);
   };
+
+  // ── Full-width bar (native-app style) ──────────────────────────────────
+  if (variant === 'bar') {
+    const renderBarSlot = (item: MobileDockItem): ReactNode => {
+      const label = typeof item.label === 'function' ? item.label() : item.label;
+      const isActive = Boolean(item.to && activeTo && item.to === activeTo);
+      const isBrand = item.emphasis === 'brand';
+      const iconEl = isBrand ? (
+        <span className="flex size-8 items-center justify-center rounded-full bg-[#5B2D8C] text-white">
+          {renderIcon(item.icon, 20)}
+        </span>
+      ) : (
+        renderIcon(item.icon, 25)
+      );
+      let toneClass = 'text-muted-foreground hover:text-foreground';
+      if (isBrand) toneClass = 'text-muted-foreground';
+      else if (isActive) toneClass = 'font-medium text-primary';
+      const slotClass = cn(
+        'flex w-full flex-col items-center justify-center gap-1 py-2 text-[11px] leading-none transition-colors',
+        toneClass
+      );
+      const children = (
+        <>
+          <span className="relative flex items-center justify-center">
+            {iconEl}
+            {item.badge ? (
+              <span className="absolute -top-0.5 -right-1 size-2 rounded-full bg-primary ring-2 ring-card" />
+            ) : null}
+          </span>
+          <span>{label}</span>
+        </>
+      );
+
+      if (item.to && !item.action) {
+        if (renderLink) {
+          return renderLink({
+            to: item.to,
+            isActive,
+            className: slotClass,
+            children,
+            onNavigate: () => undefined,
+            linkProps: {
+              href: item.to,
+              className: slotClass,
+              'aria-label': label,
+              'aria-current': isActive ? 'page' : undefined,
+            },
+          });
+        }
+        return (
+          <a
+            href={item.to}
+            className={slotClass}
+            aria-label={label}
+            aria-current={isActive ? 'page' : undefined}
+          >
+            {children}
+          </a>
+        );
+      }
+      return (
+        <button
+          type="button"
+          onClick={() => runAction(item)}
+          aria-label={label}
+          className={slotClass}
+        >
+          {children}
+        </button>
+      );
+    };
+
+    return (
+      <nav
+        data-testid="mobile-dock"
+        aria-label="Dock"
+        className={cn(
+          'absolute inset-x-0 bottom-0 z-30 flex items-stretch border-t border-border bg-card pb-[env(safe-area-inset-bottom)]',
+          className
+        )}
+      >
+        {items.map((item) => (
+          <div key={item.id} className="flex flex-1">
+            {renderBarSlot(item)}
+          </div>
+        ))}
+      </nav>
+    );
+  }
+
+  // ── Floating pill (default) ────────────────────────────────────────────
+  const pillItems = items.filter((item) => item.emphasis !== 'brand');
+  const brandItems = items.filter((item) => item.emphasis === 'brand');
 
   const renderSlot = (item: MobileDockItem, size: number) => {
     const label = typeof item.label === 'function' ? item.label() : item.label;

--- a/src/shell/mobile-dock.stories.tsx
+++ b/src/shell/mobile-dock.stories.tsx
@@ -1,0 +1,84 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ChevronsUpDown, Home, Inbox } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { MobileDock } from './internal/mobile-dock.js';
+import { MedaShellProvider } from './shell-provider.js';
+import type { AppDefinition, MobileDockItem, WorkspaceDefinition } from './types.js';
+
+const WORKSPACE: WorkspaceDefinition = { id: 'ws', name: 'Medal Social', icon: null };
+const APPS: AppDefinition[] = [{ id: 'home', label: 'Home', icon: Home }];
+
+// Stand-in for apps/web's `PilotIcon` (the Medal brandmark) so the Storybook
+// preview matches the real dock — a purple disc with the white Medal diamond.
+function MedalMark({ size = 24 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 48 48" aria-hidden="true">
+      <circle cx="24" cy="24" r="24" fill="#5B2D8C" />
+      <path
+        d="M8 24L24 8L40 24L24 40L8 24Z"
+        stroke="#FFFFFF"
+        strokeWidth="3.5"
+        strokeLinejoin="round"
+        fill="none"
+      />
+    </svg>
+  );
+}
+
+// Matches the native app: Home · Inbox · Switch (⇅) · Pilot.
+const ITEMS: MobileDockItem[] = [
+  { id: 'home', label: 'Home', icon: Home, to: '/home' },
+  { id: 'inbox', label: 'Inbox', icon: Inbox, to: '/inbox', badge: true },
+  { id: 'switch', label: 'Switch', icon: ChevronsUpDown, action: 'open-sheet' },
+  {
+    id: 'pilot',
+    label: 'Pilot',
+    icon: MedalMark as MobileDockItem['icon'],
+    to: '/pilot',
+    emphasis: 'brand',
+  },
+];
+
+// The dock only paints on a mobile viewport (max-width: 767px) — render the
+// story at ≤767px to see it.
+function Frame({ children }: { children: ReactNode }) {
+  return (
+    <MedaShellProvider
+      workspace={WORKSPACE}
+      apps={APPS}
+      storage={{ load: () => null, save: () => undefined }}
+    >
+      <div
+        style={{
+          position: 'relative',
+          height: '100vh',
+          background: 'var(--background, #ffffff)',
+        }}
+      >
+        <div style={{ padding: 16, fontSize: 13, color: 'var(--muted-foreground, #78716c)' }}>
+          Mobile dock — render at ≤767px.
+        </div>
+        {children}
+      </div>
+    </MedaShellProvider>
+  );
+}
+
+const meta: Meta<typeof MobileDock> = {
+  title: 'Shell/MobileDock',
+  component: MobileDock,
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    (Story) => (
+      <Frame>
+        <Story />
+      </Frame>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof MobileDock>;
+
+export const Bar: Story = { args: { items: ITEMS, activeTo: '/inbox', variant: 'bar' } };
+export const Pill: Story = { args: { items: ITEMS, activeTo: '/home', variant: 'pill' } };

--- a/src/shell/types.ts
+++ b/src/shell/types.ts
@@ -151,6 +151,14 @@ export interface AppShellMobileNavConfig {
   activeTo?: string;
   /** Render dock/sheet targets as router links (else plain `<a>`). */
   renderLink?: (args: MobileNavLinkArgs) => ReactNode;
+  /**
+   * Dock presentation:
+   * - `pill` (default) — a floating, centered pill of icon-only slots with any
+   *   `emphasis: 'brand'` item as a standalone circle beside it.
+   * - `bar` — a flat, full-width bottom bar of evenly-spread slots, each with a
+   *   larger icon + label and a tinted active state (mirrors the native app).
+   */
+  variant?: 'pill' | 'bar';
 }
 
 export interface ShellRenderContext {

--- a/test/unit/shell/mobile-dock.test.tsx
+++ b/test/unit/shell/mobile-dock.test.tsx
@@ -104,4 +104,22 @@ describe('MobileDock', () => {
     );
     expect(screen.queryByTestId('mobile-dock')).toBeNull();
   });
+
+  it('renders a full-width labeled bar with a tinted active slot in the bar variant', () => {
+    render(
+      <Wrapper>
+        <MobileDock items={dockItems} variant="bar" activeTo="/inbox" />
+      </Wrapper>
+    );
+    expect(screen.getByTestId('mobile-dock')).toBeInTheDocument();
+    // The bar shows visible text labels (the pill variant is icon-only).
+    expect(screen.getByText('Home')).toBeInTheDocument();
+    expect(screen.getByText('Pilot')).toBeInTheDocument();
+    // The active destination is tinted and carries aria-current.
+    const inbox = screen.getByRole('link', { name: 'Inbox' });
+    expect(inbox).toHaveAttribute('aria-current', 'page');
+    expect(inbox.className).toContain('text-primary');
+    // The sheet trigger still opens the workspace sheet.
+    expect(screen.getByRole('button', { name: 'Open navigation' })).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary

Adds an opt-in `bar` shape to the mobile dock (`AppShellMobileNavConfig.variant`), alongside the default `pill`. The `bar` renders a flat, full-width bottom bar of evenly-spread slots — each a larger icon + label with a tinted (`text-primary`) active state — mirroring the native mobile app. Any `emphasis: 'brand'` item (e.g. Pilot) sits inline as the last slot.

Fully additive: consumers that omit `variant` keep the floating pill.

## Changes

- `AppShellMobileNavConfig.variant` + `MobileDockProps.variant` (`'pill' | 'bar'`)
- `MobileDock` renders the bar layout when `variant='bar'`
- `AppShellWorkspace` threads `variant` through
- New `Shell/MobileDock` Storybook story (Bar + Pill)

## Testing

- New bar-variant unit test; full suite green
- typecheck + biome clean
- Verified rendered in Storybook at 375px

Changeset: **minor** (→ 2.7.0).